### PR TITLE
feat: add peer queries mutations and views

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
     "name": "app",
-    "version": "0.1.9",
+    "version": "0.1.10",
     "private": true,
     "dependencies": {
         "@apollo/react-hooks": "^3.1.3",

--- a/client/src/components/modal/closeChannel/CloseChannel.tsx
+++ b/client/src/components/modal/closeChannel/CloseChannel.tsx
@@ -1,14 +1,19 @@
 import React, { useState, useEffect } from 'react';
-import { CLOSE_CHANNEL } from '../../graphql/mutation';
+import { CLOSE_CHANNEL } from '../../../graphql/mutation';
 import { useMutation, useQuery } from '@apollo/react-hooks';
-import { Separation, SingleLine, SubTitle, Sub4Title } from '../generic/Styled';
-import { AlertTriangle } from '../generic/Icons';
+import {
+    Separation,
+    SingleLine,
+    SubTitle,
+    Sub4Title,
+} from '../../generic/Styled';
+import { AlertTriangle } from '../../generic/Icons';
 import styled from 'styled-components';
 import { toast } from 'react-toastify';
-import { getErrorContent } from '../../utils/error';
-import { GET_BITCOIN_FEES } from '../../graphql/query';
-import { SecureButton } from '../buttons/secureButton/SecureButton';
-import { ColorButton } from '../buttons/colorButton/ColorButton';
+import { getErrorContent } from '../../../utils/error';
+import { GET_BITCOIN_FEES } from '../../../graphql/query';
+import { SecureButton } from '../../buttons/secureButton/SecureButton';
+import { ColorButton } from '../../buttons/colorButton/ColorButton';
 import {
     MultiButton,
     SingleButton,
@@ -47,7 +52,7 @@ export const CloseChannel = ({
     const [hour, setHour] = useState(0);
 
     const { data: feeData } = useQuery(GET_BITCOIN_FEES, {
-        onError: error => toast.error(getErrorContent(error)),
+        onError: (error) => toast.error(getErrorContent(error)),
     });
 
     useEffect(() => {
@@ -61,12 +66,12 @@ export const CloseChannel = ({
     }, [feeData]);
 
     const [closeChannel] = useMutation(CLOSE_CHANNEL, {
-        onCompleted: data => {
+        onCompleted: (data) => {
             if (data.closeChannel) {
                 toast.success('Channel Closed');
             }
         },
-        onError: error => toast.error(getErrorContent(error)),
+        onError: (error) => toast.error(getErrorContent(error)),
         refetchQueries: [
             'GetChannels',
             'GetPendingChannels',
@@ -91,26 +96,23 @@ export const CloseChannel = ({
         <WarningCard>
             <AlertTriangle size={'32px'} color={'red'} />
             <SubTitle>Are you sure you want to close the channel?</SubTitle>
-            <Sub4Title>{`${channelName} [${channelId}]`}</Sub4Title>
-            <div onClick={() => setModalOpen(false)}>
-                <SecureButton
-                    callback={closeChannel}
-                    variables={{
-                        id: channelId,
-                        forceClose: isForce,
-                        ...(isType !== 'none'
-                            ? isType === 'fee'
-                                ? { tokens: amount }
-                                : { target: amount }
-                            : {}),
-                    }}
-                    color={'red'}
-                    disabled={false}
-                    withMargin={'4px'}
-                >
-                    Close Channel
-                </SecureButton>
-            </div>
+            <SecureButton
+                callback={closeChannel}
+                variables={{
+                    id: channelId,
+                    forceClose: isForce,
+                    ...(isType !== 'none'
+                        ? isType === 'fee'
+                            ? { tokens: amount }
+                            : { target: amount }
+                        : {}),
+                }}
+                color={'red'}
+                disabled={false}
+                withMargin={'4px'}
+            >
+                {`Close Channel [ ${channelName}/${channelId} ]`}
+            </SecureButton>
             <ColorButton withMargin={'4px'} onClick={handleOnlyClose}>
                 Cancel
             </ColorButton>
@@ -180,7 +182,9 @@ export const CloseChannel = ({
                                 isType === 'target' ? 'Blocks' : 'Sats/Byte'
                             }
                             type={'number'}
-                            onChange={e => setAmount(parseInt(e.target.value))}
+                            onChange={(e) =>
+                                setAmount(parseInt(e.target.value))
+                            }
                         />
                     </SingleLine>
                 </>

--- a/client/src/components/modal/removePeer/RemovePeer.tsx
+++ b/client/src/components/modal/removePeer/RemovePeer.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { REMOVE_PEER } from '../../../graphql/mutation';
+import { useMutation } from '@apollo/react-hooks';
+import { SubTitle } from '../../generic/Styled';
+import { AlertTriangle } from '../../generic/Icons';
+import styled from 'styled-components';
+import { toast } from 'react-toastify';
+import { getErrorContent } from '../../../utils/error';
+import { SecureButton } from '../../buttons/secureButton/SecureButton';
+import { ColorButton } from '../../buttons/colorButton/ColorButton';
+
+interface RemovePeerProps {
+    setModalOpen: (status: boolean) => void;
+    publicKey: string;
+    peerAlias: string;
+}
+
+const WarningCard = styled.div`
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+`;
+
+export const RemovePeerModal = ({
+    setModalOpen,
+    publicKey,
+    peerAlias,
+}: RemovePeerProps) => {
+    const [removePeer, { loading }] = useMutation(REMOVE_PEER, {
+        onCompleted: (data) => {
+            toast.success('Peer Removed');
+        },
+        onError: (error) => {
+            toast.error(getErrorContent(error));
+        },
+        refetchQueries: ['GetPeers'],
+    });
+
+    const handleOnlyClose = () => setModalOpen(false);
+
+    return (
+        <WarningCard>
+            <AlertTriangle size={'32px'} color={'red'} />
+            <SubTitle>Are you sure you want to remove this peer?</SubTitle>
+            <SecureButton
+                callback={removePeer}
+                variables={{
+                    publicKey: publicKey,
+                }}
+                color={'red'}
+                disabled={loading}
+                withMargin={'4px'}
+            >
+                {`Remove Peer [${peerAlias ?? 'Unknown'}]`}
+            </SecureButton>
+            <ColorButton withMargin={'4px'} onClick={handleOnlyClose}>
+                Cancel
+            </ColorButton>
+        </WarningCard>
+    );
+};

--- a/client/src/graphql/mutation.ts
+++ b/client/src/graphql/mutation.ts
@@ -135,3 +135,25 @@ export const PAY_VIA_ROUTE = gql`
         payViaRoute(auth: $auth, route: $route)
     }
 `;
+
+export const REMOVE_PEER = gql`
+    mutation RemovePeer($auth: authType!, $publicKey: String!) {
+        removePeer(auth: $auth, publicKey: $publicKey)
+    }
+`;
+
+export const ADD_PEER = gql`
+    mutation AddPeer(
+        $auth: authType!
+        $publicKey: String!
+        $socket: String!
+        $isTemporary: Boolean
+    ) {
+        addPeer(
+            auth: $auth
+            publicKey: $publicKey
+            socket: $socket
+            isTemporary: $isTemporary
+        )
+    }
+`;

--- a/client/src/graphql/query.ts
+++ b/client/src/graphql/query.ts
@@ -323,3 +323,26 @@ export const GET_ROUTES = gql`
         )
     }
 `;
+
+export const GET_PEERS = gql`
+    query GetPeers($auth: authType!) {
+        getPeers(auth: $auth) {
+            bytes_received
+            bytes_sent
+            is_inbound
+            is_sync_peer
+            ping_time
+            public_key
+            socket
+            tokens_received
+            tokens_sent
+            partner_node_info {
+                alias
+                capacity
+                channel_count
+                color
+                updated_at
+            }
+        }
+    }
+`;

--- a/client/src/sections/content/Content.tsx
+++ b/client/src/sections/content/Content.tsx
@@ -22,6 +22,7 @@ import { mediaWidths } from 'styles/Themes';
 import { useConnectionState } from 'context/ConnectionContext';
 import { LoadingView, ErrorView } from 'views/stateViews/StateCards';
 import { BalanceView } from 'views/balance/Balance';
+import { PeersList } from 'views/peers/PeersList';
 
 const Container = styled.div`
     display: grid;
@@ -63,6 +64,7 @@ const Content = () => {
             <BitcoinFees />
             <Switch>
                 <Route exact path="/" render={() => getGrid(Home)} />
+                <Route path="/peers" render={() => getGrid(PeersList)} />
                 <Route path="/channels" render={() => getGrid(ChannelView)} />
                 <Route path="/balance" render={() => getGrid(BalanceView)} />
                 <Route path="/backups" render={() => getGrid(BackupsView)} />

--- a/client/src/sections/navigation/Navigation.tsx
+++ b/client/src/sections/navigation/Navigation.tsx
@@ -21,6 +21,7 @@ import {
     GitPullRequest,
     LinkIcon,
     RepeatIcon,
+    Users,
 } from '../../components/generic/Icons';
 import { useSettings } from '../../context/SettingsContext';
 import { useConnectionState } from 'context/ConnectionContext';
@@ -114,6 +115,7 @@ const BurgerNav = styled(({ selectedColor, ...rest }) => <Link {...rest} />)(
 );
 
 const HOME = '/';
+const PEERS = '/peers';
 const CHANNEL = '/channels';
 const BALANCE = '/balance';
 const TRANS = '/transactions';
@@ -159,6 +161,7 @@ export const Navigation = ({ isBurger, setOpen }: NavigationProps) => {
     const renderLinks = () => (
         <ButtonSection isOpen={sidebar}>
             {renderNavButton('Home', HOME, Home, sidebar)}
+            {renderNavButton('Peers', PEERS, Users, sidebar)}
             {renderNavButton('Channels', CHANNEL, Cpu, sidebar)}
             {renderNavButton('Balance', BALANCE, RepeatIcon, sidebar)}
             {renderNavButton('Fees', FEES, Crosshair, sidebar)}
@@ -173,6 +176,7 @@ export const Navigation = ({ isBurger, setOpen }: NavigationProps) => {
     const renderBurger = () => (
         <BurgerRow>
             {renderBurgerNav('Home', HOME, Home)}
+            {renderBurgerNav('Peers', PEERS, Users)}
             {renderBurgerNav('Channels', CHANNEL, Cpu)}
             {renderBurgerNav('Balance', BALANCE, RepeatIcon)}
             {renderBurgerNav('Fees', FEES, Crosshair)}

--- a/client/src/views/channels/channels/ChannelCard.tsx
+++ b/client/src/views/channels/channels/ChannelCard.tsx
@@ -30,7 +30,7 @@ import {
     getNodeLink,
 } from '../../../components/generic/Helpers';
 import Modal from '../../../components/modal/ReactModal';
-import { CloseChannel } from '../../../components/closeChannel/CloseChannel';
+import { CloseChannel } from '../../../components/modal/closeChannel/CloseChannel';
 import styled from 'styled-components';
 import { AdminSwitch } from '../../../components/adminSwitch/AdminSwitch';
 import { DownArrow, UpArrow, EyeOff } from '../../../components/generic/Icons';
@@ -181,7 +181,7 @@ export const ChannelCard = ({
     };
 
     return (
-        <SubCard color={nodeColor} key={index}>
+        <SubCard color={nodeColor} key={`${index}-${id}`}>
             <MainInfo onClick={() => handleClick()}>
                 <StatusLine>
                     {getStatusDot(is_active, 'active')}

--- a/client/src/views/channels/channels/Channels.tsx
+++ b/client/src/views/channels/channels/Channels.tsx
@@ -21,7 +21,7 @@ export const Channels = () => {
 
     const { loading, data } = useQuery(GET_CHANNELS, {
         variables: { auth },
-        onError: error => toast.error(getErrorContent(error)),
+        onError: (error) => toast.error(getErrorContent(error)),
     });
 
     if (loading || !data || !data.getChannels) {
@@ -36,7 +36,7 @@ export const Channels = () => {
                     index={index + 1}
                     setIndexOpen={setIndexOpen}
                     indexOpen={indexOpen}
-                    key={index}
+                    key={`${index}-${channel.id}`}
                 />
             ))}
         </Card>

--- a/client/src/views/home/account/pay/pay.tsx
+++ b/client/src/views/home/account/pay/pay.tsx
@@ -34,9 +34,9 @@ export const PayCard = ({ setOpen }: { setOpen: () => void }) => {
     );
 
     const [makePayment, { loading }] = useMutation(PAY_INVOICE, {
-        onError: error => toast.error(getErrorContent(error)),
+        onError: (error) => toast.error(getErrorContent(error)),
         onCompleted: () => {
-            toast.success('Payment Sent!');
+            toast.success('Payment Sent');
             setRequest('');
             setModalOpen(false);
             setOpen();
@@ -46,7 +46,7 @@ export const PayCard = ({ setOpen }: { setOpen: () => void }) => {
     const [decode, { data, loading: decodeLoading }] = useMutation(
         DECODE_REQUEST,
         {
-            onError: error => toast.error(getErrorContent(error)),
+            onError: (error) => toast.error(getErrorContent(error)),
         },
     );
 
@@ -89,7 +89,7 @@ export const PayCard = ({ setOpen }: { setOpen: () => void }) => {
                             ? '0 0 16px'
                             : '0 0 0 24px'
                     }
-                    onChange={e => setRequest(e.target.value)}
+                    onChange={(e) => setRequest(e.target.value)}
                 />
                 <ColorButton
                     disabled={request === ''}

--- a/client/src/views/peers/AddPeer.tsx
+++ b/client/src/views/peers/AddPeer.tsx
@@ -1,0 +1,127 @@
+import React, { useState } from 'react';
+import {
+    CardWithTitle,
+    SubTitle,
+    Card,
+    SingleLine,
+    DarkSubTitle,
+    NoWrapTitle,
+    Separation,
+    ResponsiveLine,
+    Sub4Title,
+} from 'components/generic/Styled';
+import { ColorButton } from 'components/buttons/colorButton/ColorButton';
+import { XSvg } from 'components/generic/Icons';
+import {
+    MultiButton,
+    SingleButton,
+} from 'components/buttons/multiButton/MultiButton';
+import { Input } from 'components/input/Input';
+import { mediaDimensions } from 'styles/Themes';
+import { useSize } from 'hooks/UseSize';
+import { useMutation } from '@apollo/react-hooks';
+import { toast } from 'react-toastify';
+import { getErrorContent } from 'utils/error';
+import { ADD_PEER } from 'graphql/mutation';
+import { SecureButton } from 'components/buttons/secureButton/SecureButton';
+
+export const AddPeer = () => {
+    const [isAdding, setIsAdding] = useState<boolean>(false);
+    const [temp, setTemp] = useState<boolean>(false);
+    const [key, setKey] = useState<string>('');
+    const [socket, setSocket] = useState<string>('');
+
+    const { width } = useSize();
+
+    const [addPeer, { loading }] = useMutation(ADD_PEER, {
+        onError: (error) => toast.error(getErrorContent(error)),
+        onCompleted: () => {
+            toast.success('Peer Added');
+            setIsAdding(false);
+            setTemp(false);
+            setKey('');
+            setSocket('');
+        },
+        refetchQueries: ['GetPeers'],
+    });
+
+    const renderButton = (
+        onClick: () => void,
+        text: string,
+        selected: boolean,
+    ) => (
+        <SingleButton selected={selected} onClick={onClick}>
+            {text}
+        </SingleButton>
+    );
+
+    const renderAdding = () => (
+        <>
+            <Separation />
+            <ResponsiveLine>
+                <Sub4Title style={{ whiteSpace: 'nowrap' }}>
+                    Peer Public Key:
+                </Sub4Title>
+                <Input
+                    placeholder={'Peer Public Key'}
+                    withMargin={
+                        width <= mediaDimensions.mobile
+                            ? '0 0 16px'
+                            : '0 0 0 24px'
+                    }
+                    onChange={(e) => setKey(e.target.value)}
+                />
+            </ResponsiveLine>
+            <ResponsiveLine>
+                <Sub4Title style={{ whiteSpace: 'nowrap' }}>
+                    Peer Socket:
+                </Sub4Title>
+                <Input
+                    placeholder={'Socket'}
+                    withMargin={
+                        width <= mediaDimensions.mobile
+                            ? '0 0 16px'
+                            : '0 0 0 24px'
+                    }
+                    onChange={(e) => setSocket(e.target.value)}
+                />
+            </ResponsiveLine>
+            <SingleLine>
+                <NoWrapTitle>Is Temporary:</NoWrapTitle>
+                <MultiButton>
+                    {renderButton(() => setTemp(true), 'Yes', temp)}
+                    {renderButton(() => setTemp(false), 'No', !temp)}
+                </MultiButton>
+            </SingleLine>
+            <SecureButton
+                callback={addPeer}
+                variables={{ publicKey: key, socket, isTemporary: temp }}
+                disabled={socket === '' || key === ''}
+                withMargin={'16px 0 0'}
+                loading={loading}
+                arrow={true}
+                fullWidth={true}
+            >
+                Add
+            </SecureButton>
+        </>
+    );
+
+    return (
+        <CardWithTitle>
+            <SubTitle>Peer Management</SubTitle>
+            <Card>
+                <SingleLine>
+                    <DarkSubTitle>Add Peer</DarkSubTitle>
+                    <ColorButton
+                        withMargin={'4px 0'}
+                        onClick={() => setIsAdding((prev) => !prev)}
+                    >
+                        {isAdding ? <XSvg /> : 'Add'}
+                    </ColorButton>
+                </SingleLine>
+                {isAdding && renderAdding()}
+            </Card>
+        </CardWithTitle>
+    );
+};

--- a/client/src/views/peers/PeersCard.tsx
+++ b/client/src/views/peers/PeersCard.tsx
@@ -1,0 +1,201 @@
+import React, { useState } from 'react';
+import {
+    SubCard,
+    Separation,
+    Sub4Title,
+    ResponsiveLine,
+    ResponsiveSingle,
+    ResponsiveCol,
+    RightAlign,
+} from 'components/generic/Styled';
+import {
+    renderLine,
+    getDateDif,
+    getFormatDate,
+    getTooltipType,
+    getNodeLink,
+} from 'components/generic/Helpers';
+import styled from 'styled-components';
+import { DownArrow, UpArrow } from 'components/generic/Icons';
+import {
+    Progress,
+    ProgressBar,
+    NodeTitle,
+    MainInfo,
+} from 'views/channels/Channels.style';
+import { getPercent } from 'helpers/Helpers';
+import { useSettings } from 'context/SettingsContext';
+import ReactTooltip from 'react-tooltip';
+import { usePriceState } from 'context/PriceContext';
+import { getPrice } from 'components/price/Price';
+import { AdminSwitch } from 'components/adminSwitch/AdminSwitch';
+import { ColorButton } from 'components/buttons/colorButton/ColorButton';
+import Modal from 'components/modal/ReactModal';
+import { RemovePeerModal } from 'components/modal/removePeer/RemovePeer';
+
+const IconPadding = styled.div`
+    margin-left: 16px;
+    margin-right: 8px;
+`;
+
+const getSymbol = (status: boolean) => {
+    return status ? <DownArrow /> : <UpArrow />;
+};
+
+interface PeerProps {
+    peer: any;
+    index: number;
+    setIndexOpen: (index: number) => void;
+    indexOpen: number;
+}
+
+export const PeersCard = ({
+    peer,
+    index,
+    setIndexOpen,
+    indexOpen,
+}: PeerProps) => {
+    const [modalOpen, setModalOpen] = useState(false);
+
+    const { theme, currency } = useSettings();
+    const priceContext = usePriceState();
+
+    const format = getPrice(currency, priceContext);
+    const tooltipType = getTooltipType(theme);
+
+    const {
+        bytes_received,
+        bytes_sent,
+        is_inbound,
+        is_sync_peer,
+        ping_time,
+        public_key,
+        socket,
+        tokens_received,
+        tokens_sent,
+        partner_node_info = {},
+    } = peer;
+
+    const formatReceived = format({ amount: tokens_received });
+    const formatSent = format({ amount: tokens_sent });
+
+    const {
+        alias,
+        capacity,
+        channel_count,
+        color,
+        updated_at,
+    } = partner_node_info;
+
+    const handleClick = () => {
+        if (indexOpen === index) {
+            setIndexOpen(0);
+        } else {
+            setIndexOpen(index);
+        }
+    };
+
+    const renderDetails = () => {
+        return (
+            <>
+                <Separation />
+                {renderLine('Tokens Received:', formatReceived)}
+                {renderLine('Tokens Sent:', formatSent)}
+                {renderLine('bytes Received:', bytes_received)}
+                {renderLine('bytes Sent:', bytes_sent)}
+                {renderLine('Public Key:', getNodeLink(public_key))}
+                {renderLine('Socket:', socket)}
+                {renderLine('Is Inbound:', is_inbound.toString())}
+                {renderLine('Is Sync Peer:', is_sync_peer.toString())}
+                {renderLine('Ping Time:', ping_time)}
+                <Sub4Title>Partner Node Info</Sub4Title>
+                {renderLine('Node Capacity:', capacity)}
+                {renderLine('Channel Count:', channel_count)}
+                {renderLine(
+                    'Last Update:',
+                    `${getDateDif(updated_at)} ago (${getFormatDate(
+                        updated_at,
+                    )})`,
+                )}
+                <AdminSwitch>
+                    <Separation />
+                    <RightAlign>
+                        <ColorButton
+                            withBorder={true}
+                            arrow={true}
+                            onClick={() => setModalOpen(true)}
+                        >
+                            Remove Peer
+                        </ColorButton>
+                    </RightAlign>
+                </AdminSwitch>
+            </>
+        );
+    };
+
+    return (
+        <SubCard key={`${index}-${public_key}`} color={color}>
+            <MainInfo onClick={() => handleClick()}>
+                <ResponsiveLine>
+                    <NodeTitle style={{ flexGrow: 2 }}>
+                        {alias ? alias : 'Unknown'}
+                    </NodeTitle>
+                    <ResponsiveSingle>
+                        <IconPadding>{getSymbol(is_inbound)}</IconPadding>
+                        <ResponsiveCol>
+                            <Progress
+                                data-tip
+                                data-for={`node_balance_tip_${index}`}
+                            >
+                                <ProgressBar
+                                    percent={getPercent(
+                                        bytes_received,
+                                        bytes_sent,
+                                    )}
+                                />
+                            </Progress>
+                            <Progress
+                                data-tip
+                                data-for={`node_activity_tip_${index}`}
+                            >
+                                <ProgressBar
+                                    order={2}
+                                    percent={getPercent(
+                                        tokens_received,
+                                        tokens_sent,
+                                    )}
+                                />
+                            </Progress>
+                        </ResponsiveCol>
+                    </ResponsiveSingle>
+                </ResponsiveLine>
+            </MainInfo>
+            {index === indexOpen && renderDetails()}
+            <ReactTooltip
+                id={`node_balance_tip_${index}`}
+                effect={'solid'}
+                place={'bottom'}
+                type={tooltipType}
+            >
+                <div>{`bytes Received: ${bytes_received}`}</div>
+                <div>{`bytes Sent: ${bytes_sent}`}</div>
+            </ReactTooltip>
+            <ReactTooltip
+                id={`node_activity_tip_${index}`}
+                effect={'solid'}
+                place={'bottom'}
+                type={tooltipType}
+            >
+                <div>{`Tokens Received: ${formatReceived}`}</div>
+                <div>{`Tokens Sent: ${formatSent}`}</div>
+            </ReactTooltip>
+            <Modal isOpen={modalOpen} closeCallback={() => setModalOpen(false)}>
+                <RemovePeerModal
+                    setModalOpen={setModalOpen}
+                    publicKey={public_key}
+                    peerAlias={alias}
+                />
+            </Modal>
+        </SubCard>
+    );
+};

--- a/client/src/views/peers/PeersList.tsx
+++ b/client/src/views/peers/PeersList.tsx
@@ -1,0 +1,49 @@
+import React, { useState } from 'react';
+import { useQuery } from '@apollo/react-hooks';
+import { GET_PEERS } from 'graphql/query';
+import { useAccount } from 'context/AccountContext';
+import { getAuthString } from 'utils/auth';
+import { CardWithTitle, SubTitle, Card } from 'components/generic/Styled';
+import { PeersCard } from './PeersCard';
+import { LoadingCard } from 'components/loading/LoadingCard';
+import { AddPeer } from './AddPeer';
+
+export const PeersList = () => {
+    const [indexOpen, setIndexOpen] = useState(0);
+    const { host, viewOnly, cert, sessionAdmin } = useAccount();
+    const auth = getAuthString(
+        host,
+        viewOnly !== '' ? viewOnly : sessionAdmin,
+        cert,
+    );
+
+    const { loading, data } = useQuery(GET_PEERS, {
+        variables: { auth },
+    });
+
+    console.log(data, loading);
+
+    if (loading || !data || !data.getPeers) {
+        return <LoadingCard title={'Peers'} />;
+    }
+
+    return (
+        <>
+            <AddPeer />
+            <CardWithTitle>
+                <SubTitle>Peers</SubTitle>
+                <Card>
+                    {data.getPeers.map((peer: any, index: number) => (
+                        <PeersCard
+                            peer={peer}
+                            index={index + 1}
+                            setIndexOpen={setIndexOpen}
+                            indexOpen={indexOpen}
+                            key={`${index}-${peer.public_key}`}
+                        />
+                    ))}
+                </Card>
+            </CardWithTitle>
+        </>
+    );
+};

--- a/docs/LNDAPICoverage.md
+++ b/docs/LNDAPICoverage.md
@@ -15,9 +15,9 @@ Coverage of LND's API
 - [x] NewAddress
 - [ ] SignMessage
 - [ ] VerifyMessage
-- [ ] ConnectPeer
-- [ ] DisconnectPeer
-- [ ] ListPeers
+- [x] ConnectPeer
+- [x] DisconnectPeer
+- [x] ListPeers
 - [x] GetInfo
 - [x] PendingChannels
 - [x] ListChannels

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
     "name": "thunderhub",
-    "version": "0.1.4",
+    "version": "0.1.5",
     "description": "",
     "main": "index.js",
     "scripts": {

--- a/server/src/schemas/mutations/index.ts
+++ b/server/src/schemas/mutations/index.ts
@@ -1,5 +1,6 @@
 import { channels } from './channels';
 import { invoices } from './invoices';
 import { onChain } from './onchain';
+import { peers } from './peers';
 
-export const mutation = { ...channels, ...invoices, ...onChain };
+export const mutation = { ...channels, ...invoices, ...onChain, ...peers };

--- a/server/src/schemas/mutations/peers/addPeer.ts
+++ b/server/src/schemas/mutations/peers/addPeer.ts
@@ -1,0 +1,34 @@
+import { addPeer as addLnPeer } from 'ln-service';
+import { logger } from '../../../helpers/logger';
+import { requestLimiter } from '../../../helpers/rateLimiter';
+import { GraphQLBoolean, GraphQLString, GraphQLNonNull } from 'graphql';
+import { getErrorMsg, getAuthLnd } from '../../../helpers/helpers';
+import { defaultParams } from '../../../helpers/defaultProps';
+
+export const addPeer = {
+    type: GraphQLBoolean,
+    args: {
+        ...defaultParams,
+        publicKey: { type: new GraphQLNonNull(GraphQLString) },
+        socket: { type: new GraphQLNonNull(GraphQLString) },
+        isTemporary: { type: GraphQLBoolean },
+    },
+    resolve: async (root: any, params: any, context: any) => {
+        await requestLimiter(context.ip, 'addPeer');
+
+        const lnd = getAuthLnd(params.auth);
+
+        try {
+            const success: boolean = await addLnPeer({
+                lnd,
+                public_key: params.publicKey,
+                socket: params.socket,
+                is_temporary: params.isTemporary,
+            });
+            return success;
+        } catch (error) {
+            params.logger && logger.error('Error adding peer: %o', error);
+            throw new Error(getErrorMsg(error));
+        }
+    },
+};

--- a/server/src/schemas/mutations/peers/index.ts
+++ b/server/src/schemas/mutations/peers/index.ts
@@ -1,0 +1,7 @@
+import { addPeer } from './addPeer';
+import { removePeer } from './removePeer';
+
+export const peers = {
+    addPeer,
+    removePeer,
+};

--- a/server/src/schemas/mutations/peers/removePeer.ts
+++ b/server/src/schemas/mutations/peers/removePeer.ts
@@ -1,0 +1,30 @@
+import { removePeer as removeLnPeer } from 'ln-service';
+import { logger } from '../../../helpers/logger';
+import { requestLimiter } from '../../../helpers/rateLimiter';
+import { GraphQLBoolean, GraphQLString, GraphQLNonNull } from 'graphql';
+import { getErrorMsg, getAuthLnd } from '../../../helpers/helpers';
+import { defaultParams } from '../../../helpers/defaultProps';
+
+export const removePeer = {
+    type: GraphQLBoolean,
+    args: {
+        ...defaultParams,
+        publicKey: { type: new GraphQLNonNull(GraphQLString) },
+    },
+    resolve: async (root: any, params: any, context: any) => {
+        await requestLimiter(context.ip, 'removePeer');
+
+        const lnd = getAuthLnd(params.auth);
+
+        try {
+            const success: boolean = await removeLnPeer({
+                lnd,
+                public_key: params.publicKey,
+            });
+            return success;
+        } catch (error) {
+            params.logger && logger.error('Error removing peer: %o', error);
+            throw new Error(getErrorMsg(error));
+        }
+    },
+};

--- a/server/src/schemas/query/index.ts
+++ b/server/src/schemas/query/index.ts
@@ -6,6 +6,7 @@ import { reportQueries } from './report';
 import { flowQueries } from './flow';
 import { backupQueries } from './backup';
 import { routeQueries } from './route';
+import { peerQueries } from './peer';
 
 export const query = {
     ...channelQueries,
@@ -16,4 +17,5 @@ export const query = {
     ...flowQueries,
     ...backupQueries,
     ...routeQueries,
+    ...peerQueries,
 };

--- a/server/src/schemas/query/peer/getPeers.ts
+++ b/server/src/schemas/query/peer/getPeers.ts
@@ -1,0 +1,64 @@
+import { GraphQLList } from 'graphql';
+import { getPeers as getLnPeers, getNode } from 'ln-service';
+import { logger } from '../../../helpers/logger';
+import { requestLimiter } from '../../../helpers/rateLimiter';
+import { getErrorMsg, getAuthLnd } from '../../../helpers/helpers';
+
+import { defaultParams } from '../../../helpers/defaultProps';
+import { PeerType } from './getPeers.types';
+
+interface PeerProps {
+    bytes_received: number;
+    bytes_sent: number;
+    is_inbound: boolean;
+    is_sync_peer: boolean;
+    ping_time: number;
+    public_key: string;
+    socket: string;
+    tokens_received: number;
+    tokens_sent: number;
+}
+
+export const getPeers = {
+    type: new GraphQLList(PeerType),
+    args: defaultParams,
+    resolve: async (root: any, params: any, context: any) => {
+        await requestLimiter(context.ip, 'getPeers');
+
+        const lnd = getAuthLnd(params.auth);
+
+        try {
+            const { peers }: { peers: PeerProps[] } = await getLnPeers({
+                lnd,
+            });
+
+            const getPeerList = () =>
+                Promise.all(
+                    peers.map(async (peer) => {
+                        try {
+                            const nodeInfo = await getNode({
+                                lnd,
+                                is_omitting_channels: true,
+                                public_key: peer.public_key,
+                            });
+
+                            return {
+                                ...peer,
+                                partner_node_info: {
+                                    ...nodeInfo,
+                                },
+                            };
+                        } catch (error) {
+                            return { ...peer, partner_node_info: {} };
+                        }
+                    }),
+                );
+
+            const peerList = await getPeerList();
+            return peerList;
+        } catch (error) {
+            params.logger && logger.error('Error getting peers: %o', error);
+            throw new Error(getErrorMsg(error));
+        }
+    },
+};

--- a/server/src/schemas/query/peer/getPeers.types.ts
+++ b/server/src/schemas/query/peer/getPeers.types.ts
@@ -1,0 +1,21 @@
+import { GraphQLObjectType, GraphQLBoolean, GraphQLString } from 'graphql';
+import { GraphQLInt } from 'graphql';
+import { PartnerNodeType } from '../../../schemaTypes/query/channels/channels';
+
+export const PeerType = new GraphQLObjectType({
+    name: 'peerType',
+    fields: () => {
+        return {
+            bytes_received: { type: GraphQLInt },
+            bytes_sent: { type: GraphQLInt },
+            is_inbound: { type: GraphQLBoolean },
+            is_sync_peer: { type: GraphQLBoolean },
+            ping_time: { type: GraphQLInt },
+            public_key: { type: GraphQLString },
+            socket: { type: GraphQLString },
+            tokens_received: { type: GraphQLInt },
+            tokens_sent: { type: GraphQLInt },
+            partner_node_info: { type: PartnerNodeType },
+        };
+    },
+});

--- a/server/src/schemas/query/peer/index.ts
+++ b/server/src/schemas/query/peer/index.ts
@@ -1,0 +1,5 @@
+import { getPeers } from './getPeers';
+
+export const peerQueries = {
+    getPeers,
+};

--- a/server/src/utils/rateLimitConfig.ts
+++ b/server/src/utils/rateLimitConfig.ts
@@ -41,4 +41,7 @@ export const RateConfig: RateConfigProps = {
     getRoutes: { max: 3, window: '1s' },
     payViaRoute: { max: 3, window: '1s' },
     adminCheck: { max: 3, window: '1s' },
+    getPeers: { max: 3, window: '1s' },
+    addPeer: { max: 3, window: '1s' },
+    removePeer: { max: 3, window: '1s' },
 };


### PR DESCRIPTION
# Add Peer Management

## Server

-   Add `getPeers` query
-   Add `addPeer` mutation
-   Add `removePeer` mutation

## Client

-   Add Peer view
-   Add `removePeer` modal
-   Add `addPeer` button

## General

-   Update LND coverage doc
-   Organize Modal folder
-   Small Index Refactor