### PR TITLE
fix: catching getChannel callback error

### DIFF
--- a/api/schemas/query/report/ForwardChannels.ts
+++ b/api/schemas/query/report/ForwardChannels.ts
@@ -54,10 +54,23 @@ export const getForwardChannelsReport = {
     }
 
     const getNodeAlias = async (id: string, publicKey: string) => {
-      const channelInfo: ChannelsProps = await getChannel({
-        lnd,
-        id,
-      });
+      let channelInfo: ChannelsProps;
+      try {
+        channelInfo = await getChannel({
+          lnd,
+          id,
+        });
+      } catch (error) {
+        if (error[1] == 'FullChannelDetailsNotFound') {
+          return {
+            alias: 'Edge Zombie or not found',
+            color: '#000000',
+          };
+        }
+
+        logger.error('Error getting channel / node information: %o', error);
+        throw new Error(getErrorMsg(error));
+      }
 
       const partnerPublicKey =
         channelInfo.policies[0].public_key !== publicKey

--- a/api/schemas/query/transactions/forwards.ts
+++ b/api/schemas/query/transactions/forwards.ts
@@ -62,10 +62,23 @@ export const getForwards = {
     });
 
     const getNodeAlias = async (id: string, publicKey: string) => {
-      const channelInfo: ChannelsProps = await getChannel({
-        lnd,
-        id,
-      });
+      let channelInfo: ChannelsProps;
+      try {
+        channelInfo = await getChannel({
+          lnd,
+          id,
+        });
+      } catch (error) {
+        if (error[1] == 'FullChannelDetailsNotFound') {
+          return {
+            alias: 'Edge Zombie or not found',
+            color: '#000000',
+          };
+        }
+
+        logger.error('Error getting channel / node information: %o', error);
+        throw new Error(getErrorMsg(error));
+      }
 
       const partnerPublicKey =
         channelInfo.policies[0].public_key !== publicKey


### PR DESCRIPTION
Catching FullChannelDetailsNotFound on the getChannel call we do using the lightning library, this seems to be a response we get if the channel edge is not found or is a zombie one.

It seems the callback it's an array https://github.com/alexbosworth/lightning/blob/a713b58f0c1926cb926a77cdaf242ac2b4f31625/lnd_methods/info/get_channel.js#L64

We should join those calls into one so we avoid repeating code but for now this will fix the view that it's not showing at all.

fixes https://github.com/apotdevin/thunderhub/issues/45