### PR TITLE
Fix Channel details to correctly display amount and tokens

### DIFF
--- a/src/views/channels/channels/ChannelDetails.tsx
+++ b/src/views/channels/channels/ChannelDetails.tsx
@@ -64,12 +64,12 @@ export const ChannelDetails: FC<ChannelDetailsProps> = ({
   const [modalOpen, setModalOpen] = useState<string>('none');
 
   const {
-    total_amount,
     total_tokens,
-    incoming_tokens,
+    total_amount,
     incoming_amount = 200,
-    outgoing_tokens,
+    incoming_tokens,
     outgoing_amount = 150,
+    outgoing_tokens,
   } = pending_resume;
 
   const {


### PR DESCRIPTION
On v0.12.15 I get the amount and tokens switched for pending HTLCs
![image](https://user-images.githubusercontent.com/15256660/116807172-43702880-aaf7-11eb-8005-89fbe48b233d.png)
