### PR TITLE
update husky to not fail outside of git repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     "eslint-plugin-prettier": "^3.4.0",
     "eslint-plugin-react": "^7.24.0",
     "eslint-plugin-react-hooks": "^4.2.0",
-    "husky": "^7.0.0",
+    "husky": "^7.0.1",
     "jest": "^27.0.6",
     "jest-fetch-mock": "^3.0.3",
     "lint-staged": "^11.0.0",


### PR DESCRIPTION
This is to fix the arm32v7 build process ultimately.

See https://github.com/typicode/husky/issues/851#issuecomment-874725567