### PR TITLE
Change value limit of Wumbo channel to 16777215 sats

### DIFF
--- a/src/context/ConfigContext.tsx
+++ b/src/context/ConfigContext.tsx
@@ -28,7 +28,7 @@ export type channelSortTypes =
   | 'size';
 export type sortDirectionTypes = 'increase' | 'decrease';
 export type extraColumnsType = 'outgoing' | 'incoming' | 'both' | 'none';
-export type maxSatValueType = 'auto' | 1000000 | 5000000 | 10000000 | 16000000;
+export type maxSatValueType = 'auto' | 1000000 | 5000000 | 10000000 | 16777215;
 
 type State = {
   currency: string;

--- a/src/views/channels/channels/ChannelBars.tsx
+++ b/src/views/channels/channels/ChannelBars.tsx
@@ -127,7 +127,7 @@ export const ChannelBars: FC<ChannelBarsProps> = ({
             remote={getBar(remote_balance, biggest)}
             formatLocal={localBalance}
             formatRemote={remoteBalance}
-            withBorderColor={local_balance + remote_balance >= WUMBO_MIN_SIZE}
+            withBorderColor={local_balance + remote_balance > WUMBO_MIN_SIZE}
           />
         </ChannelStatsColumn>
       );

--- a/src/views/channels/channels/ChannelDetails.tsx
+++ b/src/views/channels/channels/ChannelDetails.tsx
@@ -134,7 +134,7 @@ export const ChannelDetails: FC<ChannelDetailsProps> = ({
     );
 
   const renderWumboInfo = () => {
-    if (local_balance + remote_balance >= WUMBO_MIN_SIZE) {
+    if (local_balance + remote_balance > WUMBO_MIN_SIZE) {
       return (
         <>
           <Separation />

--- a/src/views/channels/channels/ChannelManage.tsx
+++ b/src/views/channels/channels/ChannelManage.tsx
@@ -177,8 +177,8 @@ export const ChannelManage = () => {
                 <Sub4Title>Max Sat Value</Sub4Title>
                 <MultiButton>
                   <SingleButton
-                    selected={maxSatValue === 16000000}
-                    onClick={() => changeMaxValue(16000000)}
+                    selected={maxSatValue === 16777215}
+                    onClick={() => changeMaxValue(16777215)}
                   >
                     Wumbo (16m)
                   </SingleButton>


### PR DESCRIPTION
Currently, a channel larger than 16m is regarded as Wumbo. The limit is slightly higher than this.