### PR TITLE
fix: Out Channels not respected for payments

### DIFF
--- a/src/client/src/views/home/account/pay/Pay.tsx
+++ b/src/client/src/views/home/account/pay/Pay.tsx
@@ -139,7 +139,7 @@ export const Pay: React.FC<PayProps> = ({ predefinedRequest, payCallback }) => {
         title={'Out Channels'}
         isMulti={true}
         maxWidth={'300px'}
-        callback={p => setPeers(p.map(peer => peer.partner_public_key))}
+        callback={p => setPeers(p.map(peer => peer.id))}
       />
       <Separation />
       <ColorButton

--- a/src/server/modules/api/invoices/invoices.resolver.ts
+++ b/src/server/modules/api/invoices/invoices.resolver.ts
@@ -119,13 +119,14 @@ export class InvoicesResolver {
     @Args('max_fee') max_fee: number,
     @Args('max_paths') max_paths: number,
     @Args('request') request: string,
-    @Args('out', { nullable: true, type: () => [String] }) out: string[]
+    @Args('out', { nullable: true, type: () => [String] })
+    outgoing_channels: string[]
   ) {
     const props = {
       max_fee,
       max_paths,
       request,
-      out,
+      outgoing_channels,
     };
 
     this.logger.debug('Paying invoice with params', props);


### PR DESCRIPTION
This fixes issue #421.

- Changes the out value of the pay mutation from string array of node keys to string array of channel ids
- Changes lightning library prop from out to outgoing_channels so it isn't ignored when spread