### PR TITLE
Add 'from now' to time in words for future dated expiries

### DIFF
--- a/src/client/src/components/generic/helpers.tsx
+++ b/src/client/src/components/generic/helpers.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {
+  isFuture,
   format,
   formatDistanceToNowStrict,
   differenceInCalendarDays,
@@ -149,6 +150,13 @@ export const getChannelLink = (id: string) => {
 export const getDateDif = (date: string | null | undefined): string | null => {
   if (!date) return null;
   return formatDistanceToNowStrict(new Date(date));
+};
+
+export const getPastFutureStr = (
+  date: string | null | undefined
+): string | null => {
+  if (!date) return null;
+  return isFuture(new Date(date)) ? 'from now' : 'ago';
 };
 
 export const getFormatDate = (

--- a/src/client/src/views/transactions/InvoiceCard.tsx
+++ b/src/client/src/views/transactions/InvoiceCard.tsx
@@ -9,6 +9,7 @@ import { Price } from '../../components/price/Price';
 import {
   getStatusDot,
   getDateDif,
+  getPastFutureStr,
   getFormatDate,
   renderLine,
 } from '../../components/generic/helpers';
@@ -141,7 +142,9 @@ export const InvoiceCard = ({
         )}
         {renderLine(
           'Expires:',
-          `${getDateDif(expires_at)} ago (${getFormatDate(expires_at)})`
+          `${getDateDif(expires_at)} ${getPastFutureStr(
+            expires_at
+          )} (${getFormatDate(expires_at)})`
         )}
         {renderLine('Id:', id)}
         {renderLine('Chain Address:', chain_address)}


### PR DESCRIPTION
Fixes bug #152 by replacing 'ago' with 'from now' for future dated time in words strings on the Invoice card.