### PR TITLE
Make host configurable in the same manner as port.

### DIFF
--- a/src/server/main.ts
+++ b/src/server/main.ts
@@ -7,7 +7,7 @@ async function bootstrap() {
   app.useLogger(app.get(WINSTON_MODULE_NEST_PROVIDER));
   app.setGlobalPrefix(process.env.BASE_PATH || '');
 
-  await app.listen(process.env.PORT || 3000);
+  await app.listen(process.env.PORT || 3000, process.env.HOST);
   console.log(`Application is running on: ${await app.getUrl()}`);
 }
 bootstrap();


### PR DESCRIPTION
This PR addresses apotdevin#288 by letting the user specify the environment variable HOST to listen on a specific IP address, for example setting `HOST=127.0.0.1 npm run start`.

This change is backward compatible for users who do not set the `HOST` environment variable -- still will result in `undefined` being passed on to the javascript side as before.

This change is not backward compatible for users who have an environment variable `HOST` set in their runtime environment. (Not sure why they would have that set, given it is ignored by this application, but just pointing that out.)

Per node docs, https://nodejs.org/api/net.html#serverlisten: "If host is omitted, the server will accept connections on the unspecified IPv6 address (::) when IPv6 is available, or the unspecified IPv4 address (0.0.0.0) otherwise."