### PR TITLE
Show channel name and id when editing channel policy

### DIFF
--- a/src/client/pages/channels/[slug].tsx
+++ b/src/client/pages/channels/[slug].tsx
@@ -72,7 +72,13 @@ const Channel = () => {
         <SubTitle>{`${query.slug}`}</SubTitle>
       </S.row>
       <Card>
-        <ChannelDetails id={id} />
+        <ChannelDetails
+          id={id}
+          name={
+            data.getChannel.partner_node_policies?.node?.node?.alias ||
+            'Unknown'
+          }
+        />
       </Card>
       <Card>
         <CloseChannel

--- a/src/client/src/components/modal/changeDetails/ChangeDetails.tsx
+++ b/src/client/src/components/modal/changeDetails/ChangeDetails.tsx
@@ -5,8 +5,11 @@ import { getErrorContent } from '../../../../src/utils/error';
 import { InputWithDeco } from '../../../../src/components/input/InputWithDeco';
 import { ColorButton } from '../../../../src/components/buttons/colorButton/ColorButton';
 import { Input } from '../../../../src/components/input';
+import { SingleLine, SubTitle, Sub4Title } from '../../generic/Styled';
 
 type ChangeDetailsType = {
+  id?: string;
+  name?: string;
   transaction_id?: string;
   transaction_vout?: number;
   base_fee_mtokens?: string | null;
@@ -17,6 +20,8 @@ type ChangeDetailsType = {
 };
 
 export const ChangeDetails = ({
+  id,
+  name,
   transaction_id,
   transaction_vout,
   base_fee_mtokens,
@@ -51,14 +56,18 @@ export const ChangeDetails = ({
     },
     onCompleted: data => {
       data.updateFees
-        ? toast.success('Channel fees updated')
-        : toast.error('Error updating channel fees');
+        ? toast.success('Channel policy updated')
+        : toast.error('Error updating channel policy');
     },
     refetchQueries: ['GetChannels', 'ChannelFees'],
   });
 
   return (
     <>
+      <SingleLine>
+        <SubTitle>{'Update Channel Policy'}</SubTitle>
+        <Sub4Title>{`${name} [${id}]`}</Sub4Title>
+      </SingleLine>
       <InputWithDeco
         title={'Base Fee'}
         customAmount={`${newBaseFee} sats`}

--- a/src/client/src/views/channels/channels/ChannelDetails.tsx
+++ b/src/client/src/views/channels/channels/ChannelDetails.tsx
@@ -4,7 +4,10 @@ import { LoadingCard } from '../../../components/loading/LoadingCard';
 import { ChangeDetails } from '../../../components/modal/changeDetails/ChangeDetails';
 import { useGetChannelInfoQuery } from '../../../graphql/queries/__generated__/getChannel.generated';
 
-export const ChannelDetails: FC<{ id?: string }> = ({ id = '' }) => {
+export const ChannelDetails: FC<{ id?: string; name?: string }> = ({
+  id = '',
+  name = '',
+}) => {
   const { data, loading, error } = useGetChannelInfoQuery({
     variables: { id },
     skip: !id,
@@ -26,6 +29,8 @@ export const ChannelDetails: FC<{ id?: string }> = ({ id = '' }) => {
 
   return (
     <ChangeDetails
+      id={id}
+      name={name}
       transaction_id={transaction_id}
       transaction_vout={transaction_vout}
       base_fee_mtokens={node_policies?.base_fee_mtokens || '0'}

--- a/src/client/src/views/channels/channels/ChannelTable.tsx
+++ b/src/client/src/views/channels/channels/ChannelTable.tsx
@@ -534,7 +534,7 @@ export const ChannelTable = () => {
 
     switch (channel.action) {
       case 'edit':
-        return <ChannelDetails id={channel.channel} />;
+        return <ChannelDetails id={channel.channel} name={channel.name} />;
       case 'close':
         return (
           <CloseChannel


### PR DESCRIPTION
Include the channel name and id on the "Edit" modal in the same style that it's displayed on the "Close" modal. It's a nice reminder to the user of which channel they are currently editing and consistent with that information as it's displayed in the "Close" modal.

I also took the liberty of changing the toasts to refer to updating the channel "policy" instead of "fee" to reflect that a few of the parameters aren't fees. Let me know if you prefer not to make that change and I'll adjust the PR accordingly.