### PR TITLE
fix: tooltip key in tx bar chart

### DIFF
--- a/src/client/src/views/home/reports/flow/TransactionGraph.tsx
+++ b/src/client/src/views/home/reports/flow/TransactionGraph.tsx
@@ -120,7 +120,7 @@ export const TransactionsGraph: FC<TransactionsGraphProps> = ({
           priceLabel={type !== 'amount'}
           data={finalArray.map(f => {
             return {
-              Invoices: f?.[type] || 0,
+              [showPay ? 'Payments' : 'Invoices']: f?.[type] || 0,
               date: f.date,
             };
           })}


### PR DESCRIPTION
The bar chart was showing incorrect tooltip on mouseover, so I fixed it (after navigating the code).