### PR TITLE
feat: add post to keysend billboard on amboss page

### DIFF
--- a/src/client/pages/amboss/index.tsx
+++ b/src/client/pages/amboss/index.tsx
@@ -8,6 +8,7 @@ import { Backups } from '../../src/views/amboss/Backups';
 import { SectionTitle, Text } from '../../src/components/typography/Styled';
 import { Healthchecks } from '../../src/views/amboss/Healthchecks';
 import { Balances } from '../../src/views/amboss/Balances';
+import { Billboard } from '../../src/views/amboss/Billboard';
 
 const AmbossView = () => (
   <>
@@ -30,6 +31,7 @@ const Wrapped = () => (
     <Backups />
     <Healthchecks />
     <Balances />
+    <Billboard />
   </GridWrapper>
 );
 

--- a/src/client/src/views/amboss/Backups.tsx
+++ b/src/client/src/views/amboss/Backups.tsx
@@ -5,7 +5,6 @@ import {
   SubTitle,
   Separation,
   SingleLine,
-  DarkSubTitle,
 } from '../../components/generic/Styled';
 import { Text } from '../../components/typography/Styled';
 import numeral from 'numeral';
@@ -27,7 +26,7 @@ const PushBackup = () => {
 
   return (
     <SingleLine>
-      <DarkSubTitle>Push Backup to Amboss</DarkSubTitle>
+      <Text>Push Backup to Amboss</Text>
       <ColorButton
         color="#ff0080"
         withMargin={'4px 0'}

--- a/src/client/src/views/amboss/Billboard.tsx
+++ b/src/client/src/views/amboss/Billboard.tsx
@@ -6,6 +6,7 @@ import {
   Separation,
 } from '../../components/generic/Styled';
 import { Text } from '../../components/typography/Styled';
+import { Link } from '../../components/link/Link';
 
 export const Billboard = () => {
   return (
@@ -13,8 +14,15 @@ export const Billboard = () => {
       <SubTitle>Keysend Billboard</SubTitle>
       <Card>
         <Text>
-          Keysend Amboss a message and it will appear on the home page! Messages
-          are sorted by amount of sats sent and how recent it was.
+          Keysend{' '}
+          <Link
+            href="https://amboss.space/node/03006fcf3312dae8d068ea297f58e2bd00ec1ffe214b793eda46966b6294a53ce6"
+            newTab={true}
+          >
+            Amboss
+          </Link>{' '}
+          a message and it will appear on their home page! Messages are sorted
+          by amount of sats sent and how recent it was.
         </Text>
         <Separation />
         <ChatInput

--- a/src/client/src/views/amboss/Billboard.tsx
+++ b/src/client/src/views/amboss/Billboard.tsx
@@ -1,0 +1,29 @@
+import { ChatInput } from '../chat/ChatInput';
+import {
+  Card,
+  CardWithTitle,
+  SubTitle,
+  Separation,
+} from '../../components/generic/Styled';
+import { Text } from '../../components/typography/Styled';
+
+export const Billboard = () => {
+  return (
+    <CardWithTitle>
+      <SubTitle>Keysend Billboard</SubTitle>
+      <Card>
+        <Text>
+          Keysend Amboss a message and it will appear on the home page! Messages
+          are sorted by amount of sats sent and how recent it was.
+        </Text>
+        <Separation />
+        <ChatInput
+          alias={'Amboss.Space'}
+          sender={
+            '03006fcf3312dae8d068ea297f58e2bd00ec1ffe214b793eda46966b6294a53ce6'
+          }
+        />
+      </Card>
+    </CardWithTitle>
+  );
+};


### PR DESCRIPTION
Added the ability to post to the Amboss.Space keysend billboard on the Amboss page. Users can now post messages without knowing the pubkey and without having to navigate to the Chat page.

![image](https://user-images.githubusercontent.com/85003930/228074438-a3467332-0cfe-43ba-b67e-51f68d276775.png)
