### PR TITLE
Change updating documentation link

### DIFF
--- a/src/client/src/components/version/Version.tsx
+++ b/src/client/src/components/version/Version.tsx
@@ -48,7 +48,7 @@ export const Version = () => {
 
   return (
     <Link
-      href={'https://github.com/apotdevin/thunderhub#updating'}
+      href={'https://docs.thunderhub.io/installation#updating'}
       newTab={true}
     >
       <VersionBox>{`Version ${githubVersion} is available. You are on version ${npmVersion}`}</VersionBox>


### PR DESCRIPTION
## Description

Changes the "updating" section documentation link reference to ThunderHub's web page. The old link points to this repository's README but there's no information for updating ThunderHub anymore.

Alternatively, it could point to the documentation repository: https://github.com/apotdevin/thunderhub-docs/blob/main/pages/installation.mdx