### PR TITLE
fix: channel table sorting fns

### DIFF
--- a/src/client/src/views/channels/channels/ChannelTable.tsx
+++ b/src/client/src/views/channels/channels/ChannelTable.tsx
@@ -282,19 +282,19 @@ export const ChannelTable = () => {
           {
             header: 'Active',
             accessorKey: 'channelActiveLogo',
-            sortType: numberStringSorting('channelActive'),
+            sortingFn: numberStringSorting('channelActive'),
             cell: ({ cell }: any) => cell.renderValue(),
           },
           {
             header: 'Private',
             accessorKey: 'channelPrivateLogo',
-            sortType: numberStringSorting('channelPrivate'),
+            sortingFn: numberStringSorting('channelPrivate'),
             cell: ({ cell }: any) => cell.renderValue(),
           },
           {
             header: 'Initiated',
             accessorKey: 'channelOpenerLogo',
-            sortType: numberStringSorting('channelOpener'),
+            sortingFn: numberStringSorting('channelOpener'),
             cell: ({ cell }: any) => cell.renderValue(),
           },
         ],
@@ -392,7 +392,7 @@ export const ChannelTable = () => {
           {
             header: 'Percent',
             accessorKey: 'balancePercentText',
-            sortType: numberStringSorting('balancePercent'),
+            sortingFn: numberStringSorting('balancePercent'),
           },
         ],
       },
@@ -435,7 +435,7 @@ export const ChannelTable = () => {
           {
             header: 'Percent',
             accessorKey: 'percentOnlineText',
-            sortType: numberStringSorting('percentOnline'),
+            sortingFn: numberStringSorting('percentOnline'),
           },
         ],
       },
@@ -463,7 +463,7 @@ export const ChannelTable = () => {
           {
             header: 'Percent',
             accessorKey: 'activityPercentText',
-            sortType: numberStringSorting('activityPercent'),
+            sortingFn: numberStringSorting('activityPercent'),
           },
         ],
       },
@@ -501,19 +501,19 @@ export const ChannelTable = () => {
           {
             header: 'Balance',
             accessorKey: 'balanceBars',
-            sortType: numberStringSorting('balancePercent'),
+            sortingFn: numberStringSorting('balancePercent'),
             cell: ({ cell }: any) => cell.renderValue(),
           },
           {
             header: 'Proportional',
             accessorKey: 'proportionalBars',
-            sortType: numberStringSorting('balancePercent'),
+            sortingFn: numberStringSorting('balancePercent'),
             cell: ({ cell }: any) => cell.renderValue(),
           },
           {
             header: 'Activity',
             accessorKey: 'activityBars',
-            sortType: numberStringSorting('activityPercent'),
+            sortingFn: numberStringSorting('activityPercent'),
             cell: ({ cell }: any) => cell.renderValue(),
           },
         ],


### PR DESCRIPTION
Notion: https://www.notion.so/amboss-tech/fceb1d1ddc024e40b4995547eda34502?v=8fe4ee4dabd545d596e1169eac79fcd1&p=a3324fe70b994c1491983a2979a6566f&pm=s

This fixes the table sorting functions on the Channels table that were missed during the package migration.

Fixes #556 

![image](https://github.com/apotdevin/thunderhub/assets/85003930/0c17669f-ad7d-424d-884b-29427be1824a)
