### PR TITLE
add statistick to channel view

### DIFF
--- a/src/client/pages/channels/[slug].tsx
+++ b/src/client/pages/channels/[slug].tsx
@@ -15,6 +15,8 @@ import { CloseChannel } from '../../src/components/modal/closeChannel/CloseChann
 import { useGetChannelInfoQuery } from '../../src/graphql/queries/__generated__/getChannel.generated';
 import { getProps } from '../../src/utils/ssr';
 import { ChannelDetails } from '../../src/views/channels/channels/ChannelDetails';
+import React from 'react';
+import { ChannelCart } from '../../src/components/chart/ChannelChart';
 
 const S = {
   row: styled.div`
@@ -88,6 +90,9 @@ const Channel = () => {
             'Unknown'
           }
         />
+      </Card>
+      <Card>
+        <ChannelCart channelId={id} />
       </Card>
     </CardWithTitle>
   );

--- a/src/client/pages/channels/[slug].tsx
+++ b/src/client/pages/channels/[slug].tsx
@@ -15,8 +15,6 @@ import { CloseChannel } from '../../src/components/modal/closeChannel/CloseChann
 import { useGetChannelInfoQuery } from '../../src/graphql/queries/__generated__/getChannel.generated';
 import { getProps } from '../../src/utils/ssr';
 import { ChannelDetails } from '../../src/views/channels/channels/ChannelDetails';
-import React from 'react';
-import { ChannelCart } from '../../src/components/chart/ChannelChart';
 
 const S = {
   row: styled.div`
@@ -90,9 +88,6 @@ const Channel = () => {
             'Unknown'
           }
         />
-      </Card>
-      <Card>
-        <ChannelCart channelId={id} />
       </Card>
     </CardWithTitle>
   );

--- a/src/client/pages/forwards.tsx
+++ b/src/client/pages/forwards.tsx
@@ -40,7 +40,7 @@ const viewOptions = [
   { label: 'List', value: 'list' },
   { label: 'By Channel', value: 'byChannel' },
 ];
-const emptyChannel = { label: 'Chose channel', value: '' };
+const emptyChannel = { label: 'All channels', value: '' };
 
 const ForwardsView = () => {
   const [days, setDays] = useState(options[0]);
@@ -88,7 +88,11 @@ const ForwardsView = () => {
               ) : (
                 <SelectWithValue
                   callback={e => setChannel((e[0] || emptyChannel) as any)}
-                  options={channelOptions || [emptyChannel]}
+                  options={
+                    channelOptions
+                      ? [emptyChannel, ...channelOptions]
+                      : [emptyChannel]
+                  }
                   value={channel}
                   isClearable={false}
                   maxWidth={'340px'}

--- a/src/client/pages/forwards.tsx
+++ b/src/client/pages/forwards.tsx
@@ -41,7 +41,7 @@ const viewOptions = [
   { label: 'List', value: 'list' },
   { label: 'By Channel', value: 'byChannel' },
 ];
-const channelWasNotFound = { label: 'Channels was not found', value: '' };
+const emptyChannel = { label: 'Chose channel', value: '' };
 
 const ForwardsView = () => {
   const [days, setDays] = useState(options[0]);
@@ -55,9 +55,7 @@ const ForwardsView = () => {
       value: it.id,
     };
   });
-  const [channel, setChannel] = useState(
-    channelOptions ? channelOptions[0] : channelWasNotFound
-  );
+  const [channel, setChannel] = useState(emptyChannel);
 
   return (
     <>
@@ -90,10 +88,8 @@ const ForwardsView = () => {
                 />
               ) : (
                 <SelectWithValue
-                  callback={e =>
-                    setChannel((e[0] || channelWasNotFound) as any)
-                  }
-                  options={channelOptions || [channelWasNotFound]}
+                  callback={e => setChannel((e[0] || emptyChannel) as any)}
+                  options={channelOptions || [emptyChannel]}
                   value={channel}
                   isClearable={false}
                   maxWidth={'200px'}

--- a/src/client/pages/forwards.tsx
+++ b/src/client/pages/forwards.tsx
@@ -92,6 +92,7 @@ const ForwardsView = () => {
                   value={channel}
                   isClearable={false}
                   maxWidth={'340px'}
+                  minWidth={'250px'}
                 />
               )}
             </S.options>

--- a/src/client/pages/forwards.tsx
+++ b/src/client/pages/forwards.tsx
@@ -18,26 +18,35 @@ import {
   Separation,
 } from '../src/components/generic/Styled';
 import { ForwardSankey } from '../src/views/forwards/forwardSankey';
+import { ChannelCart } from '../src/components/chart/ChannelChart';
 
 const S = {
   options: styled.div`
     margin: 0 0 8px;
     width: 100%;
-    display: grid;
-    grid-gap: 8px;
-    grid-template-columns: 1fr 100px 80px 110px;
+    display: flex;
+    justify-content: space-between;
+  `,
+  temp: styled.div`
+    display: flex;
+    gap: 8px;
+    width: 40%;
+    justify-content: flex-end;
   `,
 };
 
 const viewOptions = [
   { label: 'Graph', value: 'graph' },
   { label: 'List', value: 'list' },
+  { label: 'By Channel', value: 'byChannel' },
 ];
 
 const ForwardsView = () => {
   const [days, setDays] = useState(options[0]);
   const [type, setType] = useState(typeOptions[0]);
   const [view, setView] = useState(viewOptions[0]);
+  // todo channels dropdown,
+  //  show it if  viewOption == byChannel
 
   return (
     <>
@@ -45,34 +54,39 @@ const ForwardsView = () => {
         <CardTitle>
           <S.options>
             <SubTitle>Forwards</SubTitle>
-            <SelectWithValue
-              callback={e => setView((e[0] || viewOptions[0]) as any)}
-              options={viewOptions}
-              value={view}
-              isClearable={false}
-              maxWidth={'100px'}
-            />
-            <SelectWithValue
-              callback={e => setDays((e[0] || options[1]) as any)}
-              options={options}
-              value={days}
-              isClearable={false}
-              maxWidth={'80px'}
-            />
-            <SelectWithValue
-              callback={e => setType((e[0] || typeOptions[1]) as any)}
-              options={typeOptions}
-              value={type}
-              isClearable={false}
-              maxWidth={'110px'}
-            />
+            <S.temp>
+              <SelectWithValue
+                callback={e => setView((e[0] || viewOptions[0]) as any)}
+                options={viewOptions}
+                value={view}
+                isClearable={false}
+                maxWidth={'140px'}
+              />
+              <SelectWithValue
+                callback={e => setDays((e[0] || options[1]) as any)}
+                options={options}
+                value={days}
+                isClearable={false}
+                maxWidth={'80px'}
+              />
+              {view.value != 'byChannel' && (
+                <SelectWithValue
+                  callback={e => setType((e[0] || typeOptions[1]) as any)}
+                  options={typeOptions}
+                  value={type}
+                  isClearable={false}
+                  maxWidth={'110px'}
+                />
+              )}
+            </S.temp>
           </S.options>
         </CardTitle>
-        {view.value === 'list' ? (
+        {view.value === 'list' && (
           <Card mobileCardPadding={'0'} mobileNoBackground={true}>
             <ForwardsList days={days.value} />
           </Card>
-        ) : (
+        )}
+        {view.value === 'graph' && (
           <>
             <Card mobileCardPadding={'0'} mobileNoBackground={true}>
               <ForwardsGraph days={days} type={type} />
@@ -92,6 +106,11 @@ const ForwardsView = () => {
                 type={type.value as 'amount' | 'fee' | 'tokens'}
               />
             </Card>
+          </>
+        )}
+        {view.value === 'byChannel' && (
+          <>
+            <ChannelCart channelId={'asd'} days={days.value} />
           </>
         )}
       </CardWithTitle>

--- a/src/client/pages/forwards.tsx
+++ b/src/client/pages/forwards.tsx
@@ -22,16 +22,15 @@ import { ChannelCart } from '../src/components/chart/ChannelChart';
 import { useGetChannelsQuery } from '../src/graphql/queries/__generated__/getChannels.generated';
 
 const S = {
-  options: styled.div`
+  header: styled.div`
     margin: 0 0 8px;
     width: 100%;
     display: flex;
-    justify-content: space-between;
   `,
-  temp: styled.div`
+  options: styled.div`
     display: flex;
+    flex-grow: 1;
     gap: 8px;
-    width: 80%;
     justify-content: flex-end;
   `,
 };
@@ -61,9 +60,9 @@ const ForwardsView = () => {
     <>
       <CardWithTitle>
         <CardTitle>
-          <S.options>
+          <S.header>
             <SubTitle>Forwards</SubTitle>
-            <S.temp>
+            <S.options>
               <SelectWithValue
                 callback={e => setView((e[0] || viewOptions[0]) as any)}
                 options={viewOptions}
@@ -95,8 +94,8 @@ const ForwardsView = () => {
                   maxWidth={'200px'}
                 />
               )}
-            </S.temp>
-          </S.options>
+            </S.options>
+          </S.header>
         </CardTitle>
         {view.value === 'list' && (
           <Card mobileCardPadding={'0'} mobileNoBackground={true}>

--- a/src/client/pages/forwards.tsx
+++ b/src/client/pages/forwards.tsx
@@ -75,7 +75,7 @@ const ForwardsView = () => {
                 options={options}
                 value={days}
                 isClearable={false}
-                maxWidth={'80px'}
+                maxWidth={'85px'}
               />
               {view.value != 'byChannel' ? (
                 <SelectWithValue

--- a/src/client/pages/forwards.tsx
+++ b/src/client/pages/forwards.tsx
@@ -91,7 +91,7 @@ const ForwardsView = () => {
                   options={channelOptions || [emptyChannel]}
                   value={channel}
                   isClearable={false}
-                  maxWidth={'200px'}
+                  maxWidth={'250px'}
                 />
               )}
             </S.options>

--- a/src/client/pages/forwards.tsx
+++ b/src/client/pages/forwards.tsx
@@ -48,7 +48,7 @@ const ForwardsView = () => {
   const [view, setView] = useState(viewOptions[0]);
   const channelOptions = useGetChannelsQuery().data?.getChannels.map(it => {
     return {
-      label: `${it.id} ${
+      label: `${it.id}, ${
         it.partner_node_info.node ? it.partner_node_info.node.alias : ''
       }`,
       value: it.id,
@@ -91,7 +91,7 @@ const ForwardsView = () => {
                   options={channelOptions || [emptyChannel]}
                   value={channel}
                   isClearable={false}
-                  maxWidth={'250px'}
+                  maxWidth={'340px'}
                 />
               )}
             </S.options>

--- a/src/client/src/components/chart/ChannelChart.tsx
+++ b/src/client/src/components/chart/ChannelChart.tsx
@@ -1,17 +1,30 @@
 import { useGetForwardsQuery } from '../../graphql/queries/__generated__/getForwards.generated';
 import { toast } from 'react-toastify';
 import { getErrorContent } from '../../utils/error';
-
 type ChannelCartProps = {
   channelId: string;
+  days: number;
 };
 
+/**
+ * lnd currently not support filter for channelId, so now it impossible to optimize query.
+ */
 export const ChannelCart = ({ channelId }: ChannelCartProps) => {
-  const { data, loading, error } = useGetForwardsQuery({
-    variables: { days: 7 },
+  const { data } = useGetForwardsQuery({
+    ssr: false,
+    variables: { days: 7 }, //todo change
     onError: error => toast.error(getErrorContent(error)),
   });
-  console.log(data, loading, error);
+  const filteredData = data?.getForwards.filter(
+    it => it.incoming_channel === channelId || it.outgoing_channel === channelId
+  );
+  console.log('santa', data);
+  console.log('santa', filteredData);
 
-  return <div>ChannelCart id: {channelId}</div>;
+  return (
+    <div>
+      ChannelCart id: {channelId}
+      {'filteredData'}
+    </div>
+  );
 };

--- a/src/client/src/components/chart/ChannelChart.tsx
+++ b/src/client/src/components/chart/ChannelChart.tsx
@@ -52,25 +52,24 @@ export const ChannelCart = ({ channelId, days }: ChannelCartProps) => {
     .reverse();
 
   const mEarningArr = Array<number>(columnSize).fill(0);
-  let feeReceivedArr = Array<number>(columnSize).fill(0);
-  const recieveArr = Array<number>(columnSize).fill(0);
+  let feeSendArr = Array<number>(columnSize).fill(0);
+  const receiveArr = Array<number>(columnSize).fill(0);
   const sendArr = Array<number>(columnSize).fill(0);
-  // todo fee count is for out channel or in or both direction? 038c030bb15b8c561e7b 7d check!!!
   // todo fee count is for out channel or in or both direction? 038c030bb15b8c561e7b 7d check!!!
   filteredData.forEach(it => {
     const columnIndex = calculateColumnIndex(it.created_at);
     mEarningArr[columnIndex] += Number.parseInt(it.fee_mtokens);
     if (it.outgoing_channel === channelId) {
       sendArr[columnIndex] += it.tokens;
-      feeReceivedArr[columnIndex] +=
+      feeSendArr[columnIndex] +=
         (Number.parseInt(it.fee_mtokens) / it.tokens) * 1000;
     } else {
-      recieveArr[columnIndex] += it.tokens;
+      receiveArr[columnIndex] += it.tokens;
     }
   });
   //fill zeros with previous non-zero value
   let lastNotZeroValue: number;
-  feeReceivedArr = feeReceivedArr.map(Math.round).map(it => {
+  feeSendArr = feeSendArr.map(Math.round).map(it => {
     if (it !== 0) {
       lastNotZeroValue = it;
     } else if (lastNotZeroValue !== 0) {
@@ -84,7 +83,7 @@ export const ChannelCart = ({ channelId, days }: ChannelCartProps) => {
       grid: {
         containLabel: true,
         top: '50px',
-        left: '75px',
+        left: '95px',
         bottom: '25px',
         right: '25px',
       },
@@ -99,19 +98,12 @@ export const ChannelCart = ({ channelId, days }: ChannelCartProps) => {
       },
       color: [
         chartColors.orange2,
-        chartColors.purple,
-        chartColors.green,
         chartColors.orange,
         chartColors.lightblue,
+        chartColors.green,
       ],
       legend: {
-        data: [
-          'Earning (received)',
-          'Fee (received)',
-          'Received',
-          'Earning (send)',
-          'Send',
-        ],
+        data: ['Earning', 'Fee', 'Received', 'Send'],
         itemGap: 50,
         textStyle: { color: fontColor },
       },
@@ -143,7 +135,7 @@ export const ChannelCart = ({ channelId, days }: ChannelCartProps) => {
           name: 'Fee',
           position: 'left',
           min: 0,
-          max: Math.floor(Math.max(...feeReceivedArr) + 1),
+          max: Math.floor(Math.max(...feeSendArr) + 1),
           // interval: 50,
           axisLine: { show: true, lineStyle: { color: fontColor } },
           axisLabel: {
@@ -156,7 +148,7 @@ export const ChannelCart = ({ channelId, days }: ChannelCartProps) => {
           name: 'Amount',
           position: 'right',
           min: 0,
-          max: Math.max(...recieveArr, ...sendArr),
+          max: Math.max(...receiveArr, ...sendArr),
           // interval: 5,
           axisLine: { show: true, lineStyle: { color: fontColor } },
           axisLabel: {
@@ -167,7 +159,7 @@ export const ChannelCart = ({ channelId, days }: ChannelCartProps) => {
       ],
       series: [
         {
-          name: 'Earning (received)',
+          name: 'Earning',
           type: 'line',
           yAxisIndex: 0,
           tooltip: {
@@ -176,13 +168,14 @@ export const ChannelCart = ({ channelId, days }: ChannelCartProps) => {
           data: mEarningArr.map(x => x / 1000),
         },
         {
-          name: 'Fee (received)',
+          // updated by send (out) tx
+          name: 'Fee',
           type: 'line',
           yAxisIndex: 1,
           tooltip: {
             valueFormatter: (value: string) => value + ' ppm',
           },
-          data: feeReceivedArr,
+          data: feeSendArr,
         },
         {
           name: 'Received',
@@ -191,16 +184,7 @@ export const ChannelCart = ({ channelId, days }: ChannelCartProps) => {
           tooltip: {
             valueFormatter: (value: string) => value + ' sats',
           },
-          data: recieveArr,
-        },
-        {
-          name: 'Earning (send)',
-          type: 'line',
-          yAxisIndex: 0,
-          tooltip: {
-            valueFormatter: (value: string) => value + ' sats',
-          },
-          data: mEarningArr.map(x => x / 1000),
+          data: receiveArr,
         },
         {
           name: 'Send',

--- a/src/client/src/components/chart/ChannelChart.tsx
+++ b/src/client/src/components/chart/ChannelChart.tsx
@@ -1,0 +1,17 @@
+import { useGetForwardsQuery } from '../../graphql/queries/__generated__/getForwards.generated';
+import { toast } from 'react-toastify';
+import { getErrorContent } from '../../utils/error';
+
+type ChannelCartProps = {
+  channelId: string;
+};
+
+export const ChannelCart = ({ channelId }: ChannelCartProps) => {
+  const { data, loading, error } = useGetForwardsQuery({
+    variables: { days: 7 },
+    onError: error => toast.error(getErrorContent(error)),
+  });
+  console.log(data, loading, error);
+
+  return <div>ChannelCart id: {channelId}</div>;
+};

--- a/src/client/src/components/chart/ChannelChart.tsx
+++ b/src/client/src/components/chart/ChannelChart.tsx
@@ -29,26 +29,26 @@ export const ChannelCart = ({ channelId, days }: ChannelCartProps) => {
   console.log('santa filteredData', filteredData);
   const option = useMemo(() => {
     const fontColor = themeContext.mode === 'light' ? 'black' : 'white';
+    const oppositeColor = themeContext.mode === 'light' ? 'white' : 'black';
     return {
+      grid: {
+        containLabel: true,
+        top: '50px',
+        left: '75px',
+        bottom: '25px',
+        right: '25px',
+      },
       tooltip: {
         trigger: 'axis',
         axisPointer: {
           type: 'cross',
           crossStyle: {
-            color: '#999',
+            color: fontColor,
           },
         },
       },
-      toolbox: {
-        feature: {
-          dataView: { show: true, readOnly: false },
-          magicType: { show: true, type: ['line', 'bar'] },
-          restore: { show: true },
-          saveAsImage: { show: true },
-        },
-      },
       legend: {
-        data: ['Send', 'Received', 'Fee', 'Earning'],
+        data: ['Send', 'Received', 'Earning', 'Fee'],
         itemGap: 50,
         textStyle: { color: fontColor },
         lineStyle: { shadowColor: 'blue' },
@@ -57,36 +57,53 @@ export const ChannelCart = ({ channelId, days }: ChannelCartProps) => {
         {
           type: 'category',
           data: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'],
-          axisPointer: {
-            type: 'shadow',
-          },
           axisLine: { show: true, lineStyle: { color: fontColor } },
           axisLabel: { color: fontColor },
+          axisPointer: { show: false },
         },
       ],
       yAxis: [
         {
           type: 'value',
-          name: 'Received',
+          position: 'left',
+          offset: '100',
+          name: 'Earned',
           min: 0,
           max: 250,
           interval: 50,
           axisLine: { show: true, lineStyle: { color: fontColor } },
           axisLabel: {
             color: fontColor,
-            formatter: '{value} ml',
+            formatter: '{value} sats',
           },
+          axisPointer: { label: { color: oppositeColor } },
         },
         {
           type: 'value',
           name: 'Fee',
+          position: 'left',
+          min: 0,
+          max: 250,
+          interval: 50,
+          axisLine: { show: true, lineStyle: { color: fontColor } },
+          axisLabel: {
+            color: fontColor,
+            formatter: '{value} ppm',
+          },
+          axisPointer: { label: { color: oppositeColor } },
+        },
+        {
+          type: 'value',
+          name: 'Amount',
+          position: 'right',
           min: 0,
           max: 25,
           interval: 5,
           axisLine: { show: true, lineStyle: { color: fontColor } },
           axisLabel: {
-            formatter: '{value} °C',
+            formatter: '{value} °sats',
           },
+          axisPointer: { label: { color: oppositeColor } },
         },
       ],
       series: [
@@ -94,7 +111,7 @@ export const ChannelCart = ({ channelId, days }: ChannelCartProps) => {
           name: 'Send',
           type: 'bar',
           tooltip: {
-            valueFormatter: (value: string) => value + ' ml',
+            valueFormatter: (value: string) => value + ' sats',
           },
           data: [
             2.0, 4.9, 7.0, 23.2, 25.6, 76.7, 135.6, 162.2, 32.6, 20.0, 6.4, 3.3,
@@ -104,7 +121,7 @@ export const ChannelCart = ({ channelId, days }: ChannelCartProps) => {
           name: 'Received',
           type: 'bar',
           tooltip: {
-            valueFormatter: (value: string) => value + ' ml',
+            valueFormatter: (value: string) => value + ' sats',
           },
           data: [
             2.6, 5.9, 9.0, 26.4, 28.7, 70.7, 175.6, 182.2, 48.7, 18.8, 6.0, 2.3,
@@ -115,7 +132,7 @@ export const ChannelCart = ({ channelId, days }: ChannelCartProps) => {
           type: 'line',
           yAxisIndex: 1,
           tooltip: {
-            valueFormatter: (value: string) => value + ' °C',
+            valueFormatter: (value: string) => value + ' ppm',
           },
           data: [
             2.0, 2.2, 3.3, 4.5, 6.3, 10.2, 20.3, 23.4, 23.0, 16.5, 12.0, 6.2,
@@ -126,7 +143,7 @@ export const ChannelCart = ({ channelId, days }: ChannelCartProps) => {
           type: 'line',
           yAxisIndex: 1,
           tooltip: {
-            valueFormatter: (value: string) => value + ' °C',
+            valueFormatter: (value: string) => value + ' sats',
           },
           data: [
             3.0, 5.2, 1.3, 4.5, 6.3, 10.2, 15.3, 23.4, 23.0, 10.5, 20.0, 6.2,
@@ -144,7 +161,7 @@ export const ChannelCart = ({ channelId, days }: ChannelCartProps) => {
         notMerge={true}
         lazyUpdate={true}
         showLoading={false}
-        style={{ height: '34em', marginTop: '2em' }}
+        style={{ height: '34em' }}
       />
     </Card>
   );

--- a/src/client/src/components/chart/ChannelChart.tsx
+++ b/src/client/src/components/chart/ChannelChart.tsx
@@ -28,7 +28,7 @@ export const ChannelCart = ({ channelId, days }: ChannelCartProps) => {
   );
   console.log('santa filteredData', filteredData);
   const option = useMemo(() => {
-    // const fontColor = themeContext.mode === 'light' ? 'black' : 'white';
+    const fontColor = themeContext.mode === 'light' ? 'black' : 'white';
     return {
       tooltip: {
         trigger: 'axis',
@@ -48,7 +48,10 @@ export const ChannelCart = ({ channelId, days }: ChannelCartProps) => {
         },
       },
       legend: {
-        data: ['Evaporation', 'Precipitation', 'Temperature'],
+        data: ['Send', 'Received', 'Fee', 'Earning'],
+        itemGap: 50,
+        textStyle: { color: fontColor },
+        lineStyle: { shadowColor: 'blue' },
       },
       xAxis: [
         {
@@ -57,25 +60,30 @@ export const ChannelCart = ({ channelId, days }: ChannelCartProps) => {
           axisPointer: {
             type: 'shadow',
           },
+          axisLine: { show: true, lineStyle: { color: fontColor } },
+          axisLabel: { color: fontColor },
         },
       ],
       yAxis: [
         {
           type: 'value',
-          name: 'Precipitation',
+          name: 'Received',
           min: 0,
           max: 250,
           interval: 50,
+          axisLine: { show: true, lineStyle: { color: fontColor } },
           axisLabel: {
+            color: fontColor,
             formatter: '{value} ml',
           },
         },
         {
           type: 'value',
-          name: 'Temperature',
+          name: 'Fee',
           min: 0,
           max: 25,
           interval: 5,
+          axisLine: { show: true, lineStyle: { color: fontColor } },
           axisLabel: {
             formatter: '{value} °C',
           },
@@ -83,7 +91,7 @@ export const ChannelCart = ({ channelId, days }: ChannelCartProps) => {
       ],
       series: [
         {
-          name: 'Evaporation',
+          name: 'Send',
           type: 'bar',
           tooltip: {
             valueFormatter: (value: string) => value + ' ml',
@@ -93,7 +101,7 @@ export const ChannelCart = ({ channelId, days }: ChannelCartProps) => {
           ],
         },
         {
-          name: 'Precipitation',
+          name: 'Received',
           type: 'bar',
           tooltip: {
             valueFormatter: (value: string) => value + ' ml',
@@ -103,7 +111,7 @@ export const ChannelCart = ({ channelId, days }: ChannelCartProps) => {
           ],
         },
         {
-          name: 'Temperature',
+          name: 'Fee',
           type: 'line',
           yAxisIndex: 1,
           tooltip: {
@@ -111,6 +119,17 @@ export const ChannelCart = ({ channelId, days }: ChannelCartProps) => {
           },
           data: [
             2.0, 2.2, 3.3, 4.5, 6.3, 10.2, 20.3, 23.4, 23.0, 16.5, 12.0, 6.2,
+          ],
+        },
+        {
+          name: 'Earning',
+          type: 'line',
+          yAxisIndex: 1,
+          tooltip: {
+            valueFormatter: (value: string) => value + ' °C',
+          },
+          data: [
+            3.0, 5.2, 1.3, 4.5, 6.3, 10.2, 15.3, 23.4, 23.0, 10.5, 20.0, 6.2,
           ],
         },
       ],

--- a/src/client/src/components/chart/ChannelChart.tsx
+++ b/src/client/src/components/chart/ChannelChart.tsx
@@ -38,7 +38,6 @@ export const ChannelCart = ({ channelId, days }: ChannelCartProps) => {
       )
     : [];
 
-  console.log('santa filteredData', filteredData); //todo remove
   // Helper data
   const fontColor = themeContext.mode === 'light' ? 'black' : 'white';
   const oppositeColor = themeContext.mode === 'light' ? 'white' : 'black';

--- a/src/client/src/components/chart/ChannelChart.tsx
+++ b/src/client/src/components/chart/ChannelChart.tsx
@@ -12,6 +12,7 @@ import { formatSats } from '../../utils/helpers';
 
 echarts.use([LineChart]);
 const MILLISECONDS_PER_HOUR = 1000 * 60 * 60;
+const OFFSET_MILLISECONDS = new Date().getTimezoneOffset() * 60 * 1000;
 type ChannelCartProps = { channelId: string; days: number };
 const getMaxHeight = (arr: number[], rounding?: number): number => {
   const max = Math.max(...arr);
@@ -47,7 +48,8 @@ export const ChannelCart = ({ channelId, days }: ChannelCartProps) => {
   // Helper functions
   const calculateColumnIndex = (createdAt: string): number => {
     const diffInHour = Math.floor(
-      (now.getTime() - new Date(createdAt).getTime()) / MILLISECONDS_PER_HOUR
+      (now.getTime() - new Date(createdAt).getTime() + OFFSET_MILLISECONDS) /
+        MILLISECONDS_PER_HOUR
     );
     return (
       columnSize - 1 - (days === 1 ? diffInHour : Math.floor(diffInHour / 24))

--- a/src/client/src/components/chart/ChannelChart.tsx
+++ b/src/client/src/components/chart/ChannelChart.tsx
@@ -7,8 +7,6 @@ import { useContext, useMemo } from 'react';
 import { ThemeContext } from 'styled-components';
 import { LineChart } from 'echarts/charts';
 import { Card } from '../generic/Styled';
-// import { GraphicComponent, GridComponent } from 'echarts/components';
-// import { CanvasRenderer } from 'echarts/renderers';
 echarts.use([LineChart]);
 
 type ChannelCartProps = { channelId: string; days: number };
@@ -27,6 +25,19 @@ export const ChannelCart = ({ channelId, days }: ChannelCartProps) => {
     it => it.incoming_channel === channelId || it.outgoing_channel === channelId
   );
   console.log('santa filteredData', filteredData);
+
+  const xAxisData = (): string[] => {
+    if (days === 1) {
+      return Array.from(Array(24))
+        .map((_, i) => ` ${i} hour ago`)
+        .reverse();
+    } else {
+      return Array.from(Array(days))
+        .map((_, i) => ` ${i} days ago`)
+        .reverse();
+    }
+  };
+
   const option = useMemo(() => {
     const fontColor = themeContext.mode === 'light' ? 'black' : 'white';
     const oppositeColor = themeContext.mode === 'light' ? 'white' : 'black';
@@ -39,27 +50,25 @@ export const ChannelCart = ({ channelId, days }: ChannelCartProps) => {
         right: '25px',
       },
       tooltip: {
-        trigger: 'axis',
+        trigger: 'item',
         axisPointer: {
-          type: 'cross',
+          type: 'line',
           crossStyle: {
             color: fontColor,
           },
         },
       },
       legend: {
-        data: ['Send', 'Received', 'Earning', 'Fee'],
+        data: ['Earning', 'Fee', 'Send', 'Received'],
         itemGap: 50,
         textStyle: { color: fontColor },
-        lineStyle: { shadowColor: 'blue' },
       },
       xAxis: [
         {
           type: 'category',
-          data: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'],
+          data: xAxisData(),
           axisLine: { show: true, lineStyle: { color: fontColor } },
-          axisLabel: { color: fontColor },
-          axisPointer: { show: false },
+          axisPointer: { show: true, label: { color: oppositeColor } },
         },
       ],
       yAxis: [
@@ -73,7 +82,6 @@ export const ChannelCart = ({ channelId, days }: ChannelCartProps) => {
           interval: 50,
           axisLine: { show: true, lineStyle: { color: fontColor } },
           axisLabel: {
-            color: fontColor,
             formatter: '{value} sats',
           },
           axisPointer: { label: { color: oppositeColor } },
@@ -87,7 +95,6 @@ export const ChannelCart = ({ channelId, days }: ChannelCartProps) => {
           interval: 50,
           axisLine: { show: true, lineStyle: { color: fontColor } },
           axisLabel: {
-            color: fontColor,
             formatter: '{value} ppm',
           },
           axisPointer: { label: { color: oppositeColor } },
@@ -151,7 +158,7 @@ export const ChannelCart = ({ channelId, days }: ChannelCartProps) => {
         },
       ],
     };
-  }, [themeContext]);
+  }, [themeContext, days]);
 
   return (
     <Card>

--- a/src/client/src/components/chart/ChannelChart.tsx
+++ b/src/client/src/components/chart/ChannelChart.tsx
@@ -9,10 +9,9 @@ import { LineChart } from 'echarts/charts';
 import { Card } from '../generic/Styled';
 import { chartColors } from '../../styles/Themes';
 import { formatSats } from '../../utils/helpers';
+import { differenceInHours } from 'date-fns';
 
 echarts.use([LineChart]);
-const MILLISECONDS_PER_HOUR = 1000 * 60 * 60;
-const OFFSET_MILLISECONDS = new Date().getTimezoneOffset() * 60 * 1000;
 type ChannelCartProps = { channelId: string; days: number };
 const getMaxHeight = (arr: number[], rounding?: number): number => {
   const max = Math.max(...arr);
@@ -43,14 +42,18 @@ export const ChannelCart = ({ channelId, days }: ChannelCartProps) => {
   const fontColor = themeContext.mode === 'light' ? 'black' : 'white';
   const oppositeColor = themeContext.mode === 'light' ? 'white' : 'black';
   const columnSize = days === 1 ? 24 : days;
-  const now = new Date();
+  const now =
+    days === 1
+      ? new Date().setMinutes(0, 0, 0)
+      : new Date().setHours(0, 0, 0, 0);
 
   // Helper functions
   const calculateColumnIndex = (createdAt: string): number => {
-    const diffInHour = Math.floor(
-      (now.getTime() - new Date(createdAt).getTime() + OFFSET_MILLISECONDS) /
-        MILLISECONDS_PER_HOUR
-    );
+    const txTime =
+      days === 1
+        ? new Date(createdAt).setMinutes(0, 0, 0)
+        : new Date(createdAt).setHours(0, 0, 0, 0);
+    const diffInHour = differenceInHours(now, txTime);
     return (
       columnSize - 1 - (days === 1 ? diffInHour : Math.floor(diffInHour / 24))
     );

--- a/src/client/src/components/chart/ChannelChart.tsx
+++ b/src/client/src/components/chart/ChannelChart.tsx
@@ -9,9 +9,9 @@ import { LineChart } from 'echarts/charts';
 import { Card } from '../generic/Styled';
 import { chartColors } from '../../styles/Themes';
 import { formatSats } from '../../utils/helpers';
-import { differenceInHours } from 'date-fns';
 
 echarts.use([LineChart]);
+const MILLISECONDS_PER_HOUR = 1000 * 60 * 60;
 type ChannelCartProps = { channelId: string; days: number };
 const getMaxHeight = (arr: number[], rounding?: number): number => {
   const max = Math.max(...arr);
@@ -42,21 +42,17 @@ export const ChannelCart = ({ channelId, days }: ChannelCartProps) => {
   const fontColor = themeContext.mode === 'light' ? 'black' : 'white';
   const oppositeColor = themeContext.mode === 'light' ? 'white' : 'black';
   const columnSize = days === 1 ? 24 : days;
-  const now =
-    days === 1
-      ? new Date().setMinutes(0, 0, 0)
-      : new Date().setHours(0, 0, 0, 0);
+  const now = new Date();
 
   // Helper functions
   const calculateColumnIndex = (createdAt: string): number => {
-    const txTime =
-      days === 1
-        ? new Date(createdAt).setMinutes(0, 0, 0)
-        : new Date(createdAt).setHours(0, 0, 0, 0);
-    const diffInHour = differenceInHours(now, txTime);
-    return (
-      columnSize - 1 - (days === 1 ? diffInHour : Math.floor(diffInHour / 24))
+    const diffInHour = Math.floor(
+      (now.getTime() - new Date(createdAt).getTime()) / MILLISECONDS_PER_HOUR
     );
+    const columnIndex =
+      columnSize - 1 - (days === 1 ? diffInHour : Math.floor(diffInHour / 24));
+    //sometimes tx created before 10 min. FE: current time - createdAt = 24h10m
+    return columnIndex < 0 ? 0 : columnIndex;
   };
 
   const xAxisData = Array.from(Array(columnSize))

--- a/src/client/src/components/chart/ChannelChart.tsx
+++ b/src/client/src/components/chart/ChannelChart.tsx
@@ -1,30 +1,132 @@
 import { useGetForwardsQuery } from '../../graphql/queries/__generated__/getForwards.generated';
 import { toast } from 'react-toastify';
 import { getErrorContent } from '../../utils/error';
-type ChannelCartProps = {
-  channelId: string;
-  days: number;
-};
+import ReactEChartsCore from 'echarts-for-react/lib/core';
+import * as echarts from 'echarts/core';
+import { useContext, useMemo } from 'react';
+import { ThemeContext } from 'styled-components';
+import { LineChart } from 'echarts/charts';
+import { Card } from '../generic/Styled';
+// import { GraphicComponent, GridComponent } from 'echarts/components';
+// import { CanvasRenderer } from 'echarts/renderers';
+echarts.use([LineChart]);
+
+type ChannelCartProps = { channelId: string; days: number };
 
 /**
  * lnd currently not support filter for channelId, so now it impossible to optimize query.
  */
-export const ChannelCart = ({ channelId }: ChannelCartProps) => {
+export const ChannelCart = ({ channelId, days }: ChannelCartProps) => {
+  const themeContext = useContext(ThemeContext);
   const { data } = useGetForwardsQuery({
     ssr: false,
-    variables: { days: 7 }, //todo change
+    variables: { days: days },
     onError: error => toast.error(getErrorContent(error)),
   });
   const filteredData = data?.getForwards.filter(
     it => it.incoming_channel === channelId || it.outgoing_channel === channelId
   );
-  console.log('santa', data);
-  console.log('santa', filteredData);
+  console.log('santa filteredData', filteredData);
+  const option = useMemo(() => {
+    // const fontColor = themeContext.mode === 'light' ? 'black' : 'white';
+    return {
+      tooltip: {
+        trigger: 'axis',
+        axisPointer: {
+          type: 'cross',
+          crossStyle: {
+            color: '#999',
+          },
+        },
+      },
+      toolbox: {
+        feature: {
+          dataView: { show: true, readOnly: false },
+          magicType: { show: true, type: ['line', 'bar'] },
+          restore: { show: true },
+          saveAsImage: { show: true },
+        },
+      },
+      legend: {
+        data: ['Evaporation', 'Precipitation', 'Temperature'],
+      },
+      xAxis: [
+        {
+          type: 'category',
+          data: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'],
+          axisPointer: {
+            type: 'shadow',
+          },
+        },
+      ],
+      yAxis: [
+        {
+          type: 'value',
+          name: 'Precipitation',
+          min: 0,
+          max: 250,
+          interval: 50,
+          axisLabel: {
+            formatter: '{value} ml',
+          },
+        },
+        {
+          type: 'value',
+          name: 'Temperature',
+          min: 0,
+          max: 25,
+          interval: 5,
+          axisLabel: {
+            formatter: '{value} °C',
+          },
+        },
+      ],
+      series: [
+        {
+          name: 'Evaporation',
+          type: 'bar',
+          tooltip: {
+            valueFormatter: (value: string) => value + ' ml',
+          },
+          data: [
+            2.0, 4.9, 7.0, 23.2, 25.6, 76.7, 135.6, 162.2, 32.6, 20.0, 6.4, 3.3,
+          ],
+        },
+        {
+          name: 'Precipitation',
+          type: 'bar',
+          tooltip: {
+            valueFormatter: (value: string) => value + ' ml',
+          },
+          data: [
+            2.6, 5.9, 9.0, 26.4, 28.7, 70.7, 175.6, 182.2, 48.7, 18.8, 6.0, 2.3,
+          ],
+        },
+        {
+          name: 'Temperature',
+          type: 'line',
+          yAxisIndex: 1,
+          tooltip: {
+            valueFormatter: (value: string) => value + ' °C',
+          },
+          data: [
+            2.0, 2.2, 3.3, 4.5, 6.3, 10.2, 20.3, 23.4, 23.0, 16.5, 12.0, 6.2,
+          ],
+        },
+      ],
+    };
+  }, [themeContext]);
 
   return (
-    <div>
-      ChannelCart id: {channelId}
-      {'filteredData'}
-    </div>
+    <Card>
+      <ReactEChartsCore
+        option={option}
+        echarts={echarts}
+        notMerge={true}
+        lazyUpdate={true}
+        showLoading={false}
+        style={{ height: '34em', marginTop: '2em' }}
+      />
+    </Card>
   );
 };

--- a/src/client/src/components/chart/ChannelChart.tsx
+++ b/src/client/src/components/chart/ChannelChart.tsx
@@ -56,7 +56,7 @@ export const ChannelCart = ({ channelId, days }: ChannelCartProps) => {
       return acc;
     }, Array<number>(columnNumber).fill(0))
     .map(i => i / 1000);
-  console.log('aaa', earningArr); // todo after changing channel chart not update.
+  console.log('aaa', earningArr); // todo remove
 
   const option = useMemo(() => {
     return {
@@ -126,7 +126,7 @@ export const ChannelCart = ({ channelId, days }: ChannelCartProps) => {
           // interval: 5,
           axisLine: { show: true, lineStyle: { color: fontColor } },
           axisLabel: {
-            formatter: '{value} °sats',
+            formatter: '{value} sats',
           },
           axisPointer: { label: { color: oppositeColor } },
         },
@@ -174,7 +174,7 @@ export const ChannelCart = ({ channelId, days }: ChannelCartProps) => {
         },
       ],
     };
-  }, [themeContext, days]);
+  }, [themeContext, days, channelId]);
 
   return (
     <Card>

--- a/src/client/src/components/chart/ChannelChart.tsx
+++ b/src/client/src/components/chart/ChannelChart.tsx
@@ -122,7 +122,11 @@ export const ChannelCart = ({ channelId, days }: ChannelCartProps) => {
           type: 'category',
           data: xAxisData,
           axisLine: { show: true, lineStyle: { color: fontColor } },
-          axisPointer: { show: true, label: { color: oppositeColor } },
+          axisPointer: {
+            type: 'shadow',
+            show: true,
+            label: { color: oppositeColor },
+          },
         },
       ],
       yAxis: [
@@ -133,7 +137,8 @@ export const ChannelCart = ({ channelId, days }: ChannelCartProps) => {
           name: 'Earned',
           min: 0,
           max: getMaxHeight(mEarningArr),
-          // interval: 100,
+          splitLine: { show: false },
+          axisTick: { show: true },
           axisLine: { show: true, lineStyle: { color: fontColor } },
           axisLabel: {
             formatter: '{value} sats',
@@ -146,7 +151,8 @@ export const ChannelCart = ({ channelId, days }: ChannelCartProps) => {
           position: 'left',
           min: 0,
           max: getMaxHeight(feeSendArr),
-          // interval: 50,
+          splitLine: { show: false },
+          axisTick: { show: true },
           axisLine: { show: true, lineStyle: { color: fontColor } },
           axisLabel: {
             formatter: '{value} ppm',
@@ -159,7 +165,8 @@ export const ChannelCart = ({ channelId, days }: ChannelCartProps) => {
           position: 'right',
           min: 0,
           max: getMaxHeight([...receiveArr, ...sendArr]),
-          // interval: 5,
+          splitLine: { show: false },
+          axisTick: { show: true },
           axisLine: { show: true, lineStyle: { color: fontColor } },
           axisLabel: {
             formatter: '{value} sats',

--- a/src/client/src/components/select/index.tsx
+++ b/src/client/src/components/select/index.tsx
@@ -7,10 +7,11 @@ import {
   inputBorderColor,
   themeColors,
   selectColors,
-} from '../../../src/styles/Themes';
+} from '../../styles/Themes';
 
 type WrapperProps = {
   maxWidth?: string;
+  minWidth?: string;
   fullWidth?: boolean;
 };
 
@@ -19,6 +20,11 @@ const StyledWrapper = styled.div<WrapperProps>`
     maxWidth &&
     css`
       max-width: ${maxWidth};
+    `}
+  ${({ minWidth }) =>
+    minWidth &&
+    css`
+      min-width: ${minWidth};
     `}
   width: ${({ fullWidth }) => (fullWidth ? '100%' : 'auto')};
 `;
@@ -129,6 +135,7 @@ type SelectWithValueProps = {
   value: ValueProp | undefined;
   isMulti?: boolean;
   maxWidth?: string;
+  minWidth?: string;
   isClearable?: boolean;
   callback: (value: ValueProp[]) => void;
 };
@@ -137,6 +144,7 @@ export const SelectWithValue = ({
   isMulti,
   options,
   maxWidth,
+  minWidth,
   callback,
   value,
   isClearable = true,
@@ -149,7 +157,7 @@ export const SelectWithValue = ({
     }
   };
   return (
-    <StyledWrapper maxWidth={maxWidth} fullWidth={false}>
+    <StyledWrapper maxWidth={maxWidth} minWidth={minWidth} fullWidth={false}>
       <StyledSelect
         isMulti={isMulti}
         classNamePrefix={'Select'}

--- a/src/client/src/components/select/index.tsx
+++ b/src/client/src/components/select/index.tsx
@@ -149,7 +149,7 @@ export const SelectWithValue = ({
     }
   };
   return (
-    <StyledWrapper maxWidth={maxWidth} fullWidth={true}>
+    <StyledWrapper maxWidth={maxWidth} fullWidth={false}>
       <StyledSelect
         isMulti={isMulti}
         classNamePrefix={'Select'}


### PR DESCRIPTION
![Screenshot 2023-10-27 at 20 05 53](https://github.com/apotdevin/thunderhub/assets/11969255/9791c71a-2918-4c56-a843-5496f926b06d)
![Screenshot 2023-10-27 at 20 06 03](https://github.com/apotdevin/thunderhub/assets/11969255/2201cf40-afa2-492b-af5a-f18d12792858)

For active channels, is sometimes great to see historical fee to decide new fee policy update.
Fee is calculated by eaach out (sent) transactions.