### PR TITLE
fix: Boltz swap claim transaction fees

### DIFF
--- a/src/server/config/configuration.ts
+++ b/src/server/config/configuration.ts
@@ -93,7 +93,7 @@ export default (): ConfigType => {
     github: 'https://api.github.com/repos/apotdevin/thunderhub/releases/latest',
     lnMarkets: 'https://api.lnmarkets.com/v1',
     lnMarketsExchange: 'https://lnmarkets.com',
-    boltz: 'https://boltz.exchange/api',
+    boltz: 'https://api.boltz.exchange',
   };
 
   const npmVersion = process.env.npm_package_version || '0.0.0';

--- a/src/server/modules/api/boltz/boltz.resolver.ts
+++ b/src/server/modules/api/boltz/boltz.resolver.ts
@@ -11,7 +11,7 @@ import { WINSTON_MODULE_PROVIDER } from 'nest-winston';
 import { Logger } from 'winston';
 import { NodeService } from '../../node/node.service';
 import { BoltzService } from './boltz.service';
-import { constructClaimTransaction, detectSwap } from 'boltz-core';
+import { constructClaimTransaction, detectSwap, targetFee } from 'boltz-core';
 import { generateKeys, getHexBuffer, validateAddress } from './boltz.helpers';
 import { GraphQLError } from 'graphql';
 import { address, networks, Transaction } from 'bitcoinjs-lib';
@@ -171,10 +171,8 @@ export class BoltzResolver {
       networks.bitcoin
     );
 
-    const finalTransaction = constructClaimTransaction(
-      utxos,
-      destinationScript,
-      fee
+    const finalTransaction = targetFee(fee, absoluteFee =>
+      constructClaimTransaction(utxos, destinationScript, absoluteFee)
     );
 
     this.logger.debug('Final transaction', { finalTransaction });


### PR DESCRIPTION
I am not sure what changed, but the claim transactions that Thunderhub constructs right now are not created with the desired x sat/vbyte the user specifies but with x sat *absolute* fee.

This PR fixes the bug by using `targetFee` from `boltz-core` which allows specifying a sat/vbyte fee as parameter