### PR TITLE
bump dep, don't work with Node.js ^21.0.0 fix #580

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "dataloader": "^2.2.2",
     "date-fns": "^2.30.0",
     "dotenv": "^16.3.1",
-    "echarts": "^5.4.3",
+    "echarts": "^5.5.0",
     "echarts-for-react": "^3.0.2",
     "ecpair": "^2.0.1",
     "graphql": "^16.8.1",


### PR DESCRIPTION
ThunderHub does not work with `nodejs` ^21.0.0 due to `echarts` dependency which at the same time had an issue with its `zrender` dependency.

- `echarts`: [issue](https://github.com/apache/echarts/issues/19233)
- `zrender`: [upstream pr](https://github.com/ecomfe/zrender/pull/1036)

Solved on `zrender` ^5.5.0, bump deps on `echarts` ^5.5.0

Issue description on #580 