### PR TITLE
Set the "Max Size" setting to "false" (No) by default

### DIFF
--- a/src/client/src/views/home/liquidity/OpenChannel.tsx
+++ b/src/client/src/views/home/liquidity/OpenChannel.tsx
@@ -65,7 +65,7 @@ export const OpenChannel = ({ closeCbk }: OpenChannelProps) => {
   const [fee, setFee] = useState(0);
   const [publicKey, setPublicKey] = useState('');
   const [privateChannel, setPrivateChannel] = useState(false);
-  const [isMaxFunding, setIsMaxFunding] = useState(true);
+  const [isMaxFunding, setIsMaxFunding] = useState(false);
   const [type, setType] = useState(fetchFees ? 'none' : 'fee');
 
   const [feeRate, setFeeRate] = useState<number | null>(null);


### PR DESCRIPTION
Setting the channel Max Size to "Yes" by default should not be a good practice if you don't want to be surprised.

This is a PR to set the default Max Size setting to false (No) by default.

Before:
<img width="1020" height="74" alt="imagen" src="https://github.com/user-attachments/assets/117f62b1-049d-4a79-b54c-a64404087196" />

After:
<img width="1011" height="98" alt="imagen" src="https://github.com/user-attachments/assets/ba5b68f9-a3b2-49cc-a745-17519adbd87e" />