### PR TITLE
fix: use explicit BTC route hint for asset-sale self-pay invoice

### DIFF
--- a/src/server/modules/api/trade/trade.resolver.spec.ts
+++ b/src/server/modules/api/trade/trade.resolver.spec.ts
@@ -1,0 +1,230 @@
+jest.mock('../../node/tapd/tapd-node.service', () => ({
+  TapdNodeService: jest.fn(),
+}));
+jest.mock('../../node/node.service', () => ({
+  NodeService: jest.fn(),
+}));
+jest.mock('../../security/security.decorators', () => ({
+  CurrentUser: () => () => undefined,
+}));
+jest.mock('../../security/security.types', () => ({}));
+
+import { TradeResolver } from './trade.resolver';
+
+// Access private method for direct unit testing of return-hint construction.
+type BuildBtcReturnHint = (id: string, peerPubkey: string) => Promise<unknown>;
+
+describe('TradeResolver', () => {
+  const userId = 'test-user-id';
+  const peerPubkey = 'ab'.repeat(33);
+  const myPubkey = 'cd'.repeat(33);
+
+  const mockNodeService = {
+    getChannels: jest.fn(),
+    getChannel: jest.fn(),
+    getIdentity: jest.fn(),
+  };
+  const mockTapdNodeService = {};
+  const mockLogger = { error: jest.fn(), warn: jest.fn(), info: jest.fn() };
+
+  let resolver: TradeResolver;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockNodeService.getIdentity.mockResolvedValue({ public_key: myPubkey });
+    // Default: no gossiped policy available — exercises the fallback path
+    mockNodeService.getChannel.mockRejectedValue(
+      new Error('channel not in graph')
+    );
+    resolver = new TradeResolver(
+      mockTapdNodeService as never,
+      mockNodeService as never,
+      mockLogger as never
+    );
+  });
+
+  // ── Regression guard against upstream channelTypes mapping ──
+  // buildBtcReturnHint filters BTC channels by truthy `type`, which relies on
+  // the `lightning` package leaving SIMPLE_TAPROOT_OVERLAY unmapped (undefined)
+  // while mapping real BTC commitment types (ANCHORS, SIMPLE_TAPROOT, …) to
+  // non-empty strings. If upstream ever adds an entry for SIMPLE_TAPROOT_OVERLAY,
+  // the filter will start treating TA channels as BTC and the self-pay loop
+  // will regress. Fail fast here so a dependency bump surfaces the issue.
+
+  describe('lightning channelTypes constants (upstream regression guard)', () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const constants = require('lightning/lnd_responses/constants.json') as {
+      channelTypes: Record<string, string>;
+    };
+
+    it('does not map SIMPLE_TAPROOT_OVERLAY (TA channels must stay untyped)', () => {
+      expect(constants.channelTypes.SIMPLE_TAPROOT_OVERLAY).toBeUndefined();
+    });
+
+    it('maps real BTC commitment types to non-empty strings', () => {
+      expect(constants.channelTypes.ANCHORS).toBeTruthy();
+      expect(constants.channelTypes.SIMPLE_TAPROOT).toBeTruthy();
+      expect(constants.channelTypes.STATIC_REMOTE_KEY).toBeTruthy();
+    });
+  });
+
+  // ── buildBtcReturnHint ──
+
+  describe('buildBtcReturnHint', () => {
+    const buildHint = () => {
+      const privateResolver = resolver as unknown as {
+        buildBtcReturnHint: BuildBtcReturnHint;
+      };
+      return privateResolver.buildBtcReturnHint.call(
+        resolver,
+        userId,
+        peerPubkey
+      );
+    };
+
+    it('skips TA channels (type undefined) when selecting the BTC return channel', async () => {
+      mockNodeService.getChannels.mockResolvedValue({
+        channels: [
+          // Taproot Asset channel has the largest remote_balance but must be skipped
+          {
+            id: 'ta-channel',
+            type: undefined,
+            remote_balance: 10_000_000,
+          },
+          { id: 'btc-channel', type: 'anchor', remote_balance: 500_000 },
+        ],
+      });
+
+      const hint = await buildHint();
+
+      expect(Array.isArray(hint)).toBe(true);
+      expect((hint as Array<{ channel?: string }>)[1].channel).toBe(
+        'btc-channel'
+      );
+    });
+
+    it('picks the BTC channel with the largest remote_balance', async () => {
+      // Input order scrambled so `.find()`-style selection on the original array
+      // would pick the wrong channel — forces reliance on the sort.
+      mockNodeService.getChannels.mockResolvedValue({
+        channels: [
+          { id: 'btc-medium', type: 'anchor', remote_balance: 200_000 },
+          { id: 'btc-small', type: 'anchor', remote_balance: 50_000 },
+          { id: 'btc-largest', type: 'anchor', remote_balance: 900_000 },
+          { id: 'btc-large', type: 'anchor', remote_balance: 500_000 },
+        ],
+      });
+
+      const hint = await buildHint();
+
+      expect((hint as Array<{ channel?: string }>)[1].channel).toBe(
+        'btc-largest'
+      );
+      expect(mockNodeService.getChannel).toHaveBeenCalledWith(
+        userId,
+        'btc-largest'
+      );
+    });
+
+    it("uses the peer's gossiped policy when available", async () => {
+      mockNodeService.getChannels.mockResolvedValue({
+        channels: [{ id: 'btc-1', type: 'anchor', remote_balance: 500_000 }],
+      });
+      mockNodeService.getChannel.mockResolvedValue({
+        id: 'btc-1',
+        policies: [
+          // Our side of the channel — must be ignored
+          {
+            public_key: myPubkey,
+            base_fee_mtokens: '0',
+            fee_rate: 1,
+            cltv_delta: 144,
+          },
+          // Peer side — drives the hint
+          {
+            public_key: peerPubkey,
+            base_fee_mtokens: '500',
+            fee_rate: 750,
+            cltv_delta: 80,
+          },
+        ],
+      });
+
+      const hint = await buildHint();
+
+      expect(hint).toEqual([
+        { public_key: peerPubkey },
+        {
+          public_key: myPubkey,
+          channel: 'btc-1',
+          base_fee_mtokens: '500',
+          fee_rate: 750,
+          cltv_delta: 80,
+        },
+      ]);
+    });
+
+    it('falls back to conservative defaults when peer policy is missing from gossip', async () => {
+      mockNodeService.getChannels.mockResolvedValue({
+        channels: [{ id: 'btc-1', type: 'anchor', remote_balance: 500_000 }],
+      });
+      mockNodeService.getChannel.mockResolvedValue({
+        id: 'btc-1',
+        // Only our policy gossiped — peer hasn't announced one yet
+        policies: [
+          {
+            public_key: myPubkey,
+            base_fee_mtokens: '0',
+            fee_rate: 1,
+            cltv_delta: 144,
+          },
+        ],
+      });
+
+      const hint = await buildHint();
+
+      expect(hint).toEqual([
+        { public_key: peerPubkey },
+        {
+          public_key: myPubkey,
+          channel: 'btc-1',
+          base_fee_mtokens: '1000',
+          fee_rate: 2500,
+          cltv_delta: 40,
+        },
+      ]);
+    });
+
+    it('returns undefined when the peer has only TA channels', async () => {
+      mockNodeService.getChannels.mockResolvedValue({
+        channels: [
+          { id: 'ta-1', type: undefined, remote_balance: 10_000_000 },
+          { id: 'ta-2', type: undefined, remote_balance: 20_000_000 },
+        ],
+      });
+
+      await expect(buildHint()).resolves.toBeUndefined();
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        'No BTC channel with peer; omitting return hint',
+        expect.any(Object)
+      );
+    });
+
+    it('returns undefined when getChannels fails', async () => {
+      mockNodeService.getChannels.mockRejectedValue(new Error('rpc down'));
+
+      await expect(buildHint()).resolves.toBeUndefined();
+      // Must not have attempted identity lookup after channel fetch failure.
+      expect(mockNodeService.getIdentity).not.toHaveBeenCalled();
+    });
+
+    it('returns undefined when getIdentity fails', async () => {
+      mockNodeService.getChannels.mockResolvedValue({
+        channels: [{ id: 'btc-1', type: 'anchor', remote_balance: 100_000 }],
+      });
+      mockNodeService.getIdentity.mockRejectedValue(new Error('no identity'));
+
+      await expect(buildHint()).resolves.toBeUndefined();
+    });
+  });
+});

--- a/src/server/modules/api/trade/trade.resolver.ts
+++ b/src/server/modules/api/trade/trade.resolver.ts
@@ -342,21 +342,6 @@ export class TradeResolver {
       return undefined;
     }
 
-    // Taproot Asset channels use LND's SIMPLE_TAPROOT_OVERLAY commitment type,
-    // which the `lightning` package does not map — it leaves `type` undefined.
-    // BTC channels map to "anchor", "simplified_taproot", etc. Filtering by a
-    // truthy `type` isolates BTC channels.
-    const btcChannel = channelsResult.channels.find(
-      (ch: { type?: string; id: string }) => !!ch.type
-    );
-
-    if (!btcChannel) {
-      this.logger.warn('No BTC channel with peer; omitting return hint', {
-        peerPubkey,
-      });
-      return undefined;
-    }
-
     const [identity, identityError] = await toWithError(
       this.nodeService.getIdentity(id)
     );
@@ -368,17 +353,49 @@ export class TradeResolver {
       return undefined;
     }
 
-    // Hop fees in the hint are an upper bound for sender-side pathfinding.
-    // The edge charges its actual policy at HTLC time, so overestimating here
-    // is safe and avoids hard-coding the peer's exact fee schedule.
+    // Taproot Asset channels use LND's SIMPLE_TAPROOT_OVERLAY commitment type,
+    // which the `lightning` package does not map — it leaves `type` undefined.
+    // BTC channels map to "anchor", "simplified_taproot", etc. Filtering by a
+    // truthy `type` isolates BTC channels. Sort by `remote_balance` descending
+    // so the return leg uses the channel with the most peer-side capacity.
+    const btcChannels = channelsResult.channels
+      .filter(
+        (ch: { type?: string; id: string; remote_balance: number }) => !!ch.type
+      )
+      .sort(
+        (a: { remote_balance: number }, b: { remote_balance: number }) =>
+          b.remote_balance - a.remote_balance
+      );
+
+    const btcChannel = btcChannels[0];
+
+    if (!btcChannel) {
+      this.logger.warn('No BTC channel with peer; omitting return hint', {
+        peerPubkey,
+      });
+      return undefined;
+    }
+
+    // Pull the peer's gossiped policy for this channel so the hint reflects the
+    // fees they actually advertise. Falls back to a conservative upper bound
+    // when gossip isn't available (e.g. private or freshly opened channel) —
+    // LND only uses the hint to budget routes; the peer re-applies its real
+    // policy at HTLC time.
+    const [channelInfo] = await toWithError(
+      this.nodeService.getChannel(id, btcChannel.id)
+    );
+    const peerPolicy = channelInfo?.policies?.find(
+      (policy: { public_key: string }) => policy.public_key === peerPubkey
+    );
+
     return [
       { public_key: peerPubkey },
       {
         public_key: identity.public_key,
         channel: btcChannel.id,
-        base_fee_mtokens: '1000',
-        fee_rate: 100,
-        cltv_delta: 40,
+        base_fee_mtokens: peerPolicy?.base_fee_mtokens ?? '1000',
+        fee_rate: peerPolicy?.fee_rate ?? 2500, // parts per million
+        cltv_delta: peerPolicy?.cltv_delta ?? 40,
       },
     ];
   }

--- a/src/server/modules/api/trade/trade.resolver.ts
+++ b/src/server/modules/api/trade/trade.resolver.ts
@@ -3,6 +3,7 @@ import { Inject } from '@nestjs/common';
 import { WINSTON_MODULE_PROVIDER } from 'nest-winston';
 import { Logger } from 'winston';
 import { GraphQLError } from 'graphql';
+import type { Route } from 'lightning';
 import { TapdNodeService } from '../../node/tapd/tapd-node.service';
 import { NodeService } from '../../node/node.service';
 import { CurrentUser } from '../../security/security.decorators';
@@ -259,8 +260,20 @@ export class TradeResolver {
       throw new GraphQLError('Derived sats amount is zero or negative');
     }
 
+    // Self-payment loop: assets leave via the TA channel (forced first hop by
+    // tapd/RFQ) and the sats return leg comes back via the BTC channel. If we
+    // let LND auto-include private channel hints (is_including_private_channels),
+    // the TA channel also gets advertised — htlcswitch then rejects the forward
+    // with "same incoming and outgoing channel" because tapd already picked the
+    // TA channel for the outgoing hop. Build an explicit BTC-only route hint
+    // instead so pathfinding only sees the valid return path.
+    const btcHopHint = await this.buildBtcReturnHint(id, input.peerPubkey);
+
     const [invoice, invoiceError] = await toWithError(
-      this.nodeService.createInvoice(id, { tokens: invoiceSats })
+      this.nodeService.createInvoice(id, {
+        tokens: invoiceSats,
+        routes: btcHopHint ? [btcHopHint] : undefined,
+      })
     );
 
     if (invoiceError || !invoice?.request) {
@@ -299,6 +312,75 @@ export class TradeResolver {
       satsAmount: String(invoiceSats),
       feeSats: payResult.feeSat ? String(payResult.feeSat) : undefined,
     };
+  }
+
+  /**
+   * Builds a single-hop BOLT11 route hint covering the BTC return leg from
+   * the edge peer back to the trader. Skips the Taproot Asset channel so the
+   * self-payment loop does not try to return funds over the same channel that
+   * carried the outgoing asset HTLC.
+   *
+   * Returns undefined when no suitable BTC channel is found; the caller omits
+   * the hint entirely in that case.
+   */
+  private async buildBtcReturnHint(
+    id: string,
+    peerPubkey: string
+  ): Promise<Route | undefined> {
+    const [channelsResult, channelsError] = await toWithError(
+      this.nodeService.getChannels(id, {
+        partner_public_key: peerPubkey,
+        is_active: true,
+      })
+    );
+
+    if (channelsError || !channelsResult?.channels?.length) {
+      this.logger.warn(
+        'Could not fetch channels for BTC return hint; omitting hint',
+        { error: channelsError, peerPubkey }
+      );
+      return undefined;
+    }
+
+    // Taproot Asset channels use LND's SIMPLE_TAPROOT_OVERLAY commitment type,
+    // which the `lightning` package does not map — it leaves `type` undefined.
+    // BTC channels map to "anchor", "simplified_taproot", etc. Filtering by a
+    // truthy `type` isolates BTC channels.
+    const btcChannel = channelsResult.channels.find(
+      (ch: { type?: string; id: string }) => !!ch.type
+    );
+
+    if (!btcChannel) {
+      this.logger.warn('No BTC channel with peer; omitting return hint', {
+        peerPubkey,
+      });
+      return undefined;
+    }
+
+    const [identity, identityError] = await toWithError(
+      this.nodeService.getIdentity(id)
+    );
+
+    if (identityError || !identity?.public_key) {
+      this.logger.warn('Could not fetch identity for return hint; omitting', {
+        error: identityError,
+      });
+      return undefined;
+    }
+
+    // Hop fees in the hint are an upper bound for sender-side pathfinding.
+    // The edge charges its actual policy at HTLC time, so overestimating here
+    // is safe and avoids hard-coding the peer's exact fee schedule.
+    return [
+      { public_key: peerPubkey },
+      {
+        public_key: identity.public_key,
+        channel: btcChannel.id,
+        base_fee_mtokens: '1000',
+        fee_rate: 100,
+        cltv_delta: 40,
+      },
+    ];
   }
 
   /**

--- a/src/server/modules/node/lightning.types.ts
+++ b/src/server/modules/node/lightning.types.ts
@@ -1,4 +1,5 @@
 import EventEmitter from 'events';
+import { Routes } from 'lightning';
 
 // ─── Account types ───────────────────────────────────────────────
 
@@ -89,6 +90,7 @@ export type CreateInvoiceOptions = {
   is_including_private_channels?: boolean;
   is_fallback_included?: boolean;
   secret?: string;
+  routes?: Routes;
 };
 
 export type PayViaPaymentDetailsOptions = {


### PR DESCRIPTION
## Summary

- Self-payment loop for Taproot asset sales was failing with \`same incoming and outgoing channel\` → \`FAILURE_REASON_NO_ROUTE\` → \`UnknownNextPeer\`. Root cause: LND's automatic private channel hints (\`is_including_private_channels\`) advertised both the TA channel and the BTC channel on the BOLT11 invoice; tapd then forced the TA channel for the outgoing asset HTLC, and pathfinding tried to use the same TA channel for the return leg — htlcswitch rejected it.
- Build an explicit single-hop BOLT11 route hint covering only the BTC return channel in \`TradeResolver.executeSale\`, so the sender only ever sees the valid return path. The TA channel is identified by its unmapped \`SIMPLE_TAPROOT_OVERLAY\` commitment type (the \`lightning\` package leaves \`type\` \`undefined\` for TA channels) and skipped.
- Fall back to omitting the hint gracefully if the channel lookup, identity lookup, or BTC-channel match fails — the trade will still be attempted, just without the hint.

## Test plan

- [ ] Run an asset SALE end-to-end through \`TradeResolver.executeSale\` and confirm the HTLC reaches the edge peer (no \`UnknownNextPeer\`).
- [ ] Confirm a trader with only a TA channel (no BTC channel) gracefully falls back to no hint and logs a warning.
- [ ] Confirm a trader with offline peer channels returns a warning and proceeds without hint.
- [x] \`npm run lint:check\` passes
- [x] \`npm run test\` passes (101/101)
- [x] \`npm run build:nest\` succeeds