### PR TITLE
feat: add BTC liquidity safeguard to asset trade flow

### DIFF
--- a/src/client/src/views/assets/TradeSheet.tsx
+++ b/src/client/src/views/assets/TradeSheet.tsx
@@ -270,6 +270,15 @@ export const TradeSheet: FC<TradeSheetProps> = ({
   const loading = openChannelLoading || setupLoading || tradeLoading;
   const hasRate = !!rate && rate !== '0';
 
+  // Safeguard: the quoted sats amount can exceed our BTC liquidity with the
+  // peer (e.g. rate changed since the balance checks above). For buys the
+  // trader pays out via their local BTC balance; for sells the sats leg comes
+  // back via the peer's local balance (our remote).
+  const quotedSatsNum = quotedSats ? Number(quotedSats) : 0;
+  const btcBalanceForTrade = isAssetPurchase ? totalBtcLocal : totalBtcRemote;
+  const quotedSatsInsufficient =
+    quotedSatsNum > 0 && btcBalanceForTrade < quotedSatsNum;
+
   const displaySats = quotedSats || (hasRate ? satsAmount : null);
   const satsLabel = displaySats
     ? `${Number(displaySats).toLocaleString()} sats`
@@ -364,6 +373,12 @@ export const TradeSheet: FC<TradeSheetProps> = ({
     if (!amount || !offer.node.pubkey) return;
     if (!displaySats || displaySats === '0') {
       toast.error('No valid quote available — please go back and try again');
+      return;
+    }
+    if (quotedSatsInsufficient) {
+      toast.error(
+        `Quoted ${quotedSatsNum.toLocaleString()} sats exceeds available BTC liquidity with peer`
+      );
       return;
     }
     const assetAtomicAmount = String(displayToAtomic(amount, assetPrecision));
@@ -633,6 +648,15 @@ export const TradeSheet: FC<TradeSheetProps> = ({
                         {receiveLabel}
                       </div>
                     </div>
+                    {quotedSatsInsufficient && (
+                      <div className="rounded-md border border-red-500/30 bg-red-500/5 p-3 text-sm text-red-600">
+                        Quoted {quotedSatsNum.toLocaleString()} sats exceeds
+                        available {isAssetPurchase ? 'outbound' : 'inbound'} BTC
+                        liquidity with this peer (
+                        {btcBalanceForTrade.toLocaleString()} sats). Rebalance
+                        or reduce trade size.
+                      </div>
+                    )}
                   </div>
                 )}
               </div>
@@ -729,7 +753,11 @@ export const TradeSheet: FC<TradeSheetProps> = ({
                   size="lg"
                   onClick={handleTrade}
                   disabled={
-                    loading || quoteLoading || !displaySats || quoteExpired
+                    loading ||
+                    quoteLoading ||
+                    !displaySats ||
+                    quoteExpired ||
+                    quotedSatsInsufficient
                   }
                   className="flex-1"
                 >

--- a/src/server/modules/api/trade/trade.resolver.ts
+++ b/src/server/modules/api/trade/trade.resolver.ts
@@ -183,6 +183,27 @@ export class TradeResolver {
       );
     }
 
+    // Decode the invoice so we know the exact sats leg before paying it,
+    // then verify we actually have enough local BTC liquidity with the peer.
+    // Fails fast with a friendly error instead of letting the payment stall.
+    const [decoded, decodeError] = await toWithError(
+      this.nodeService.decodePaymentRequest(id, paymentRequest)
+    );
+
+    if (decodeError || decoded?.tokens == null) {
+      this.logger.error('Failed to decode asset invoice before buy', {
+        error: decodeError,
+      });
+      throw new GraphQLError('Failed to decode asset invoice');
+    }
+
+    await this.assertBtcLiquidity(
+      id,
+      input.peerPubkey,
+      decoded.tokens,
+      'local'
+    );
+
     this.logger.info('Executing buy trade', {
       assetAmount: input.assetAmount,
       invoicePrefix: paymentRequest.slice(0, 20),
@@ -259,6 +280,11 @@ export class TradeResolver {
       throw new GraphQLError('Derived sats amount is zero or negative');
     }
 
+    // For sells, the sats return leg comes from the peer's local balance (our
+    // remote). Check that up front so we fail with a clear message instead of
+    // triggering a routing failure partway through.
+    await this.assertBtcLiquidity(id, input.peerPubkey, invoiceSats, 'remote');
+
     const [invoice, invoiceError] = await toWithError(
       this.nodeService.createInvoice(id, { tokens: invoiceSats })
     );
@@ -299,6 +325,69 @@ export class TradeResolver {
       satsAmount: String(invoiceSats),
       feeSats: payResult.feeSat ? String(payResult.feeSat) : undefined,
     };
+  }
+
+  /**
+   * Finds all active BTC channels with the given peer. Taproot Asset channels
+   * use SIMPLE_TAPROOT_OVERLAY, which the `lightning` package does not map —
+   * it leaves `type` undefined. BTC channels map to "anchor",
+   * "simplified_taproot", etc. Filtering by a truthy `type` isolates BTC.
+   */
+  private async getBtcChannelsWithPeer(
+    id: string,
+    peerPubkey: string
+  ): Promise<Array<{ local_balance: number; remote_balance: number }>> {
+    const [channelsResult, channelsError] = await toWithError(
+      this.nodeService.getChannels(id, {
+        partner_public_key: peerPubkey,
+        is_active: true,
+      })
+    );
+
+    if (channelsError || !channelsResult?.channels?.length) {
+      return [];
+    }
+
+    return channelsResult.channels.filter(
+      (ch: { type?: string }) => !!ch.type
+    ) as Array<{ local_balance: number; remote_balance: number }>;
+  }
+
+  /**
+   * Pre-flight BTC liquidity check for the self-payment trade loop. A single
+   * Lightning payment has to flow through one channel, so we compare against
+   * the biggest balance across BTC channels with the peer (not the sum).
+   * - 'local': the trader needs enough outbound (their balance) to pay sats
+   *   out — used for buys.
+   * - 'remote': the trader needs enough inbound (peer's balance) to receive
+   *   the sats leg back — used for sells.
+   */
+  private async assertBtcLiquidity(
+    id: string,
+    peerPubkey: string,
+    requiredSats: number,
+    direction: 'local' | 'remote'
+  ): Promise<void> {
+    const channels = await this.getBtcChannelsWithPeer(id, peerPubkey);
+
+    if (channels.length === 0) {
+      throw new GraphQLError(
+        'No active BTC channel with trade partner — cannot execute trade'
+      );
+    }
+
+    const available = channels.reduce((max, ch) => {
+      const balance =
+        direction === 'local' ? ch.local_balance : ch.remote_balance;
+      return balance > max ? balance : max;
+    }, 0);
+
+    if (available < requiredSats) {
+      const label = direction === 'local' ? 'outbound' : 'inbound';
+      throw new GraphQLError(
+        `Insufficient ${label} BTC liquidity with trade partner: need ${requiredSats} sats, have ${available} sats`
+      );
+    }
   }
 
   /**


### PR DESCRIPTION
## Summary

Pre-flight BTC liquidity check in the asset trade flow. Stops a trade from failing partway through with a routing error when the sats leg of the self-payment loop does not fit within the BTC liquidity available with the trade partner.

### Server (`trade.resolver.ts`)

- **Buys (`executePurchase`)**: decode the asset invoice to read its sats amount, then verify the trader's **local** BTC balance with the peer covers it before paying.
- **Sells (`executeSale`)**: verify the peer's **local** BTC balance (our **remote**) with that peer covers the invoice sats before creating it.
- New `assertBtcLiquidity(id, peerPubkey, requiredSats, direction)` helper throws a `GraphQLError` with a clear `"need X sats, have Y sats"` message when insufficient.
- New `getBtcChannelWithPeer` helper isolates BTC channels from Taproot Asset channels (TA channels use `SIMPLE_TAPROOT_OVERLAY`, which `lightning` leaves as `type: undefined` — filter by truthy `type`).

### Client (`TradeSheet.tsx`)

- After receiving the quote, compare `quotedSats` against `totalBtcLocal` (buys) or `totalBtcRemote` (sells).
- When insufficient:
  - Renders a red inline warning in the confirm step under "You send / You receive".
  - Disables the **Execute Trade** button.
  - Early-returns from `handleTrade` with a toast, in case the user manages to trigger it.

## Test plan

- [ ] Buy an asset with local BTC balance below the quoted sats → blocked with error
- [ ] Sell an asset with remote BTC balance below the quoted sats → blocked with error
- [ ] Happy-path buy and sell still succeed when liquidity is adequate
- [ ] Client shows the warning block and disables the Execute Trade button in the insufficient case

🤖 Generated with [Claude Code](https://claude.com/claude-code)