### PR TITLE
feat: add precision parameter to asset minting

### DIFF
--- a/schema.gql
+++ b/schema.gql
@@ -566,7 +566,7 @@ type Mutation {
   loginAmboss: Boolean!
   logout: Boolean!
   magma: MagmaMutations!
-  mintTapAsset(amount: String!, assetType: TapAssetType! = NORMAL, groupKey: String, grouped: Boolean = true, name: String!, precision: Int): TapMintResponse!
+  mintTapAsset(amount: String!, assetType: TapAssetType! = NORMAL, groupKey: String, grouped: Boolean = true, name: String!, precision: Int!): TapMintResponse!
   newTapAddress(amt: Int, assetId: String, groupKey: String): TapAddress!
   openChannel(input: OpenChannelParams!): OpenOrCloseChannel!
   pay(max_fee: Float!, max_paths: Float!, out: [String!], request: String!): Boolean!

--- a/schema.gql
+++ b/schema.gql
@@ -566,7 +566,7 @@ type Mutation {
   loginAmboss: Boolean!
   logout: Boolean!
   magma: MagmaMutations!
-  mintTapAsset(amount: String!, assetType: TapAssetType! = NORMAL, groupKey: String, grouped: Boolean = true, name: String!, precision: Int!): TapMintResponse!
+  mintTapAsset(input: TapMintAssetInput!): TapMintResponse!
   newTapAddress(amt: Int, assetId: String, groupKey: String): TapAddress!
   openChannel(input: OpenChannelParams!): OpenOrCloseChannel!
   pay(max_fee: Float!, max_paths: Float!, out: [String!], request: String!): Boolean!
@@ -1065,6 +1065,15 @@ input TapFundChannelInput {
 type TapFundChannelResponse {
   outputIndex: Int!
   txid: String!
+}
+
+input TapMintAssetInput {
+  amount: String!
+  assetType: TapAssetType! = NORMAL
+  groupKey: String
+  grouped: Boolean! = true
+  name: String!
+  precision: Int!
 }
 
 type TapMintResponse {

--- a/schema.gql
+++ b/schema.gql
@@ -566,7 +566,7 @@ type Mutation {
   loginAmboss: Boolean!
   logout: Boolean!
   magma: MagmaMutations!
-  mintTapAsset(amount: String!, assetType: TapAssetType! = NORMAL, groupKey: String, grouped: Boolean = true, name: String!): TapMintResponse!
+  mintTapAsset(amount: String!, assetType: TapAssetType! = NORMAL, groupKey: String, grouped: Boolean = true, name: String!, precision: Int): TapMintResponse!
   newTapAddress(amt: Int, assetId: String, groupKey: String): TapAddress!
   openChannel(input: OpenChannelParams!): OpenOrCloseChannel!
   pay(max_fee: Float!, max_paths: Float!, out: [String!], request: String!): Boolean!

--- a/src/client/src/graphql/mutations/__generated__/mintTapAsset.generated.tsx
+++ b/src/client/src/graphql/mutations/__generated__/mintTapAsset.generated.tsx
@@ -9,7 +9,7 @@ export type MintTapAssetMutationVariables = Types.Exact<{
   assetType?: Types.InputMaybe<Types.TapAssetType>;
   grouped?: Types.InputMaybe<Types.Scalars['Boolean']['input']>;
   groupKey?: Types.InputMaybe<Types.Scalars['String']['input']>;
-  precision?: Types.InputMaybe<Types.Scalars['Int']['input']>;
+  precision: Types.Scalars['Int']['input'];
 }>;
 
 export type MintTapAssetMutation = {
@@ -24,7 +24,7 @@ export const MintTapAssetDocument = gql`
     $assetType: TapAssetType
     $grouped: Boolean
     $groupKey: String
-    $precision: Int
+    $precision: Int!
   ) {
     mintTapAsset(
       name: $name

--- a/src/client/src/graphql/mutations/__generated__/mintTapAsset.generated.tsx
+++ b/src/client/src/graphql/mutations/__generated__/mintTapAsset.generated.tsx
@@ -9,6 +9,7 @@ export type MintTapAssetMutationVariables = Types.Exact<{
   assetType?: Types.InputMaybe<Types.TapAssetType>;
   grouped?: Types.InputMaybe<Types.Scalars['Boolean']['input']>;
   groupKey?: Types.InputMaybe<Types.Scalars['String']['input']>;
+  precision?: Types.InputMaybe<Types.Scalars['Int']['input']>;
 }>;
 
 export type MintTapAssetMutation = {
@@ -23,6 +24,7 @@ export const MintTapAssetDocument = gql`
     $assetType: TapAssetType
     $grouped: Boolean
     $groupKey: String
+    $precision: Int
   ) {
     mintTapAsset(
       name: $name
@@ -30,6 +32,7 @@ export const MintTapAssetDocument = gql`
       assetType: $assetType
       grouped: $grouped
       groupKey: $groupKey
+      precision: $precision
     ) {
       batchKey
     }
@@ -58,6 +61,7 @@ export type MintTapAssetMutationFn = Apollo.MutationFunction<
  *      assetType: // value for 'assetType'
  *      grouped: // value for 'grouped'
  *      groupKey: // value for 'groupKey'
+ *      precision: // value for 'precision'
  *   },
  * });
  */

--- a/src/client/src/graphql/mutations/__generated__/mintTapAsset.generated.tsx
+++ b/src/client/src/graphql/mutations/__generated__/mintTapAsset.generated.tsx
@@ -4,12 +4,7 @@ import { gql } from '@apollo/client';
 import * as Apollo from '@apollo/client';
 const defaultOptions = {} as const;
 export type MintTapAssetMutationVariables = Types.Exact<{
-  name: Types.Scalars['String']['input'];
-  amount: Types.Scalars['String']['input'];
-  assetType?: Types.InputMaybe<Types.TapAssetType>;
-  grouped?: Types.InputMaybe<Types.Scalars['Boolean']['input']>;
-  groupKey?: Types.InputMaybe<Types.Scalars['String']['input']>;
-  precision: Types.Scalars['Int']['input'];
+  input: Types.TapMintAssetInput;
 }>;
 
 export type MintTapAssetMutation = {
@@ -18,22 +13,8 @@ export type MintTapAssetMutation = {
 };
 
 export const MintTapAssetDocument = gql`
-  mutation MintTapAsset(
-    $name: String!
-    $amount: String!
-    $assetType: TapAssetType
-    $grouped: Boolean
-    $groupKey: String
-    $precision: Int!
-  ) {
-    mintTapAsset(
-      name: $name
-      amount: $amount
-      assetType: $assetType
-      grouped: $grouped
-      groupKey: $groupKey
-      precision: $precision
-    ) {
+  mutation MintTapAsset($input: TapMintAssetInput!) {
+    mintTapAsset(input: $input) {
       batchKey
     }
   }
@@ -56,12 +37,7 @@ export type MintTapAssetMutationFn = Apollo.MutationFunction<
  * @example
  * const [mintTapAssetMutation, { data, loading, error }] = useMintTapAssetMutation({
  *   variables: {
- *      name: // value for 'name'
- *      amount: // value for 'amount'
- *      assetType: // value for 'assetType'
- *      grouped: // value for 'grouped'
- *      groupKey: // value for 'groupKey'
- *      precision: // value for 'precision'
+ *      input: // value for 'input'
  *   },
  * });
  */

--- a/src/client/src/graphql/mutations/mintTapAsset.ts
+++ b/src/client/src/graphql/mutations/mintTapAsset.ts
@@ -1,22 +1,8 @@
 import { gql } from '@apollo/client';
 
 export const MINT_TAP_ASSET = gql`
-  mutation MintTapAsset(
-    $name: String!
-    $amount: String!
-    $assetType: TapAssetType
-    $grouped: Boolean
-    $groupKey: String
-    $precision: Int!
-  ) {
-    mintTapAsset(
-      name: $name
-      amount: $amount
-      assetType: $assetType
-      grouped: $grouped
-      groupKey: $groupKey
-      precision: $precision
-    ) {
+  mutation MintTapAsset($input: TapMintAssetInput!) {
+    mintTapAsset(input: $input) {
       batchKey
     }
   }

--- a/src/client/src/graphql/mutations/mintTapAsset.ts
+++ b/src/client/src/graphql/mutations/mintTapAsset.ts
@@ -7,7 +7,7 @@ export const MINT_TAP_ASSET = gql`
     $assetType: TapAssetType
     $grouped: Boolean
     $groupKey: String
-    $precision: Int
+    $precision: Int!
   ) {
     mintTapAsset(
       name: $name

--- a/src/client/src/graphql/mutations/mintTapAsset.ts
+++ b/src/client/src/graphql/mutations/mintTapAsset.ts
@@ -7,6 +7,7 @@ export const MINT_TAP_ASSET = gql`
     $assetType: TapAssetType
     $grouped: Boolean
     $groupKey: String
+    $precision: Int
   ) {
     mintTapAsset(
       name: $name
@@ -14,6 +15,7 @@ export const MINT_TAP_ASSET = gql`
       assetType: $assetType
       grouped: $grouped
       groupKey: $groupKey
+      precision: $precision
     ) {
       batchKey
     }

--- a/src/client/src/graphql/types.ts
+++ b/src/client/src/graphql/types.ts
@@ -782,6 +782,7 @@ export type MutationMintTapAssetArgs = {
   groupKey?: InputMaybe<Scalars['String']['input']>;
   grouped?: InputMaybe<Scalars['Boolean']['input']>;
   name: Scalars['String']['input'];
+  precision?: InputMaybe<Scalars['Int']['input']>;
 };
 
 export type MutationNewTapAddressArgs = {

--- a/src/client/src/graphql/types.ts
+++ b/src/client/src/graphql/types.ts
@@ -782,7 +782,7 @@ export type MutationMintTapAssetArgs = {
   groupKey?: InputMaybe<Scalars['String']['input']>;
   grouped?: InputMaybe<Scalars['Boolean']['input']>;
   name: Scalars['String']['input'];
-  precision?: InputMaybe<Scalars['Int']['input']>;
+  precision: Scalars['Int']['input'];
 };
 
 export type MutationNewTapAddressArgs = {

--- a/src/client/src/graphql/types.ts
+++ b/src/client/src/graphql/types.ts
@@ -777,12 +777,7 @@ export type MutationLnUrlWithdrawArgs = {
 };
 
 export type MutationMintTapAssetArgs = {
-  amount: Scalars['String']['input'];
-  assetType?: TapAssetType;
-  groupKey?: InputMaybe<Scalars['String']['input']>;
-  grouped?: InputMaybe<Scalars['Boolean']['input']>;
-  name: Scalars['String']['input'];
-  precision: Scalars['Int']['input'];
+  input: TapMintAssetInput;
 };
 
 export type MutationNewTapAddressArgs = {
@@ -1482,6 +1477,15 @@ export type TapFundChannelResponse = {
   __typename?: 'TapFundChannelResponse';
   outputIndex: Scalars['Int']['output'];
   txid: Scalars['String']['output'];
+};
+
+export type TapMintAssetInput = {
+  amount: Scalars['String']['input'];
+  assetType?: TapAssetType;
+  groupKey?: InputMaybe<Scalars['String']['input']>;
+  grouped?: Scalars['Boolean']['input'];
+  name: Scalars['String']['input'];
+  precision: Scalars['Int']['input'];
 };
 
 export type TapMintResponse = {

--- a/src/client/src/views/assets/MintAsset.tsx
+++ b/src/client/src/views/assets/MintAsset.tsx
@@ -70,12 +70,14 @@ export const MintAsset: FC = () => {
     }
     mintAsset({
       variables: {
-        name,
-        amount,
-        assetType,
-        grouped,
-        groupKey: groupKey || null,
-        precision: parsedPrecision,
+        input: {
+          name,
+          amount,
+          assetType,
+          grouped,
+          groupKey: groupKey || null,
+          precision: parsedPrecision,
+        },
       },
     });
   };

--- a/src/client/src/views/assets/MintAsset.tsx
+++ b/src/client/src/views/assets/MintAsset.tsx
@@ -12,6 +12,7 @@ import { getErrorContent } from '../../utils/error';
 export const MintAsset: FC = () => {
   const [name, setName] = useState('');
   const [amount, setAmount] = useState('');
+  const [precision, setPrecision] = useState('');
   const [assetType, setAssetType] = useState(TapAssetType.Normal);
   const [grouped, setGrouped] = useState(true);
   const [groupKey, setGroupKey] = useState('');
@@ -46,6 +47,7 @@ export const MintAsset: FC = () => {
       setBatchKey(null);
       setName('');
       setAmount('');
+      setPrecision('');
       setGrouped(true);
       setGroupKey('');
     },
@@ -57,6 +59,15 @@ export const MintAsset: FC = () => {
       toast.error('Name and amount are required');
       return;
     }
+    let precisionValue: number | null = null;
+    if (precision !== '') {
+      const parsed = Number(precision);
+      if (!Number.isInteger(parsed) || parsed < 0 || parsed > 18) {
+        toast.error('Precision must be an integer between 0 and 18');
+        return;
+      }
+      precisionValue = parsed;
+    }
     mintAsset({
       variables: {
         name,
@@ -64,6 +75,7 @@ export const MintAsset: FC = () => {
         assetType,
         grouped,
         groupKey: groupKey || null,
+        precision: precisionValue,
       },
     });
   };
@@ -126,6 +138,24 @@ export const MintAsset: FC = () => {
               placeholder="1000"
               className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
             />
+          </div>
+          <div>
+            <label className="text-xs text-muted-foreground mb-1 block">
+              Precision (optional)
+            </label>
+            <input
+              type="number"
+              value={precision}
+              onChange={e => setPrecision(e.target.value)}
+              min={0}
+              max={18}
+              step={1}
+              placeholder="e.g. 2 for cent-like units"
+              className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+            />
+            <p className="text-xs text-muted-foreground mt-1">
+              Number of decimal places to display. 0–18.
+            </p>
           </div>
           <div>
             <label className="text-xs text-muted-foreground mb-1 block">

--- a/src/client/src/views/assets/MintAsset.tsx
+++ b/src/client/src/views/assets/MintAsset.tsx
@@ -55,18 +55,18 @@ export const MintAsset: FC = () => {
   });
 
   const handleMint = () => {
-    if (!name || !amount) {
-      toast.error('Name and amount are required');
+    if (!name || !amount || precision === '') {
+      toast.error('Name, amount, and precision are required');
       return;
     }
-    let precisionValue: number | null = null;
-    if (precision !== '') {
-      const parsed = Number(precision);
-      if (!Number.isInteger(parsed) || parsed < 0 || parsed > 18) {
-        toast.error('Precision must be an integer between 0 and 18');
-        return;
-      }
-      precisionValue = parsed;
+    const parsedPrecision = Number(precision);
+    if (
+      !Number.isInteger(parsedPrecision) ||
+      parsedPrecision < 0 ||
+      parsedPrecision > 18
+    ) {
+      toast.error('Precision must be an integer between 0 and 18');
+      return;
     }
     mintAsset({
       variables: {
@@ -75,7 +75,7 @@ export const MintAsset: FC = () => {
         assetType,
         grouped,
         groupKey: groupKey || null,
-        precision: precisionValue,
+        precision: parsedPrecision,
       },
     });
   };
@@ -141,7 +141,7 @@ export const MintAsset: FC = () => {
           </div>
           <div>
             <label className="text-xs text-muted-foreground mb-1 block">
-              Precision (optional)
+              Precision
             </label>
             <input
               type="number"
@@ -173,7 +173,7 @@ export const MintAsset: FC = () => {
           <div className="flex gap-2">
             <Button
               onClick={handleMint}
-              disabled={minting || !name || !amount}
+              disabled={minting || !name || !amount || precision === ''}
               size="sm"
             >
               {minting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}

--- a/src/server/modules/api/tapd/tapd.resolver.spec.ts
+++ b/src/server/modules/api/tapd/tapd.resolver.spec.ts
@@ -591,7 +591,8 @@ describe('TapdResolver', () => {
         'TestCoin',
         '1000',
         TapAssetType.NORMAL,
-        true
+        true,
+        0
       );
 
       expect(result.batchKey).toBe('aabb');
@@ -608,30 +609,12 @@ describe('TapdResolver', () => {
         '1000',
         TapAssetType.NORMAL,
         true,
-        undefined,
         2
       );
 
       expect(service.mintAsset).toHaveBeenCalledWith(
         expect.objectContaining({ decimalDisplay: 2 })
       );
-    });
-
-    it('omits decimalDisplay when precision is not provided', async () => {
-      service.mintAsset.mockResolvedValue({
-        pendingBatch: { batchKey: Buffer.from('aabb', 'hex') },
-      });
-
-      await resolver.mintTapAsset(
-        userId,
-        'TestCoin',
-        '1000',
-        TapAssetType.NORMAL,
-        true
-      );
-
-      const call = service.mintAsset.mock.calls[0][0];
-      expect(call).not.toHaveProperty('decimalDisplay');
     });
 
     it('rejects precision above 18', async () => {
@@ -642,7 +625,6 @@ describe('TapdResolver', () => {
           '1000',
           TapAssetType.NORMAL,
           true,
-          undefined,
           19
         )
       ).rejects.toThrow(GraphQLError);
@@ -657,7 +639,6 @@ describe('TapdResolver', () => {
           '1000',
           TapAssetType.NORMAL,
           true,
-          undefined,
           -1
         )
       ).rejects.toThrow(GraphQLError);

--- a/src/server/modules/api/tapd/tapd.resolver.spec.ts
+++ b/src/server/modules/api/tapd/tapd.resolver.spec.ts
@@ -596,6 +596,73 @@ describe('TapdResolver', () => {
 
       expect(result.batchKey).toBe('aabb');
     });
+
+    it('forwards precision as decimalDisplay to the service', async () => {
+      service.mintAsset.mockResolvedValue({
+        pendingBatch: { batchKey: Buffer.from('aabb', 'hex') },
+      });
+
+      await resolver.mintTapAsset(
+        userId,
+        'TestCoin',
+        '1000',
+        TapAssetType.NORMAL,
+        true,
+        undefined,
+        2
+      );
+
+      expect(service.mintAsset).toHaveBeenCalledWith(
+        expect.objectContaining({ decimalDisplay: 2 })
+      );
+    });
+
+    it('omits decimalDisplay when precision is not provided', async () => {
+      service.mintAsset.mockResolvedValue({
+        pendingBatch: { batchKey: Buffer.from('aabb', 'hex') },
+      });
+
+      await resolver.mintTapAsset(
+        userId,
+        'TestCoin',
+        '1000',
+        TapAssetType.NORMAL,
+        true
+      );
+
+      const call = service.mintAsset.mock.calls[0][0];
+      expect(call).not.toHaveProperty('decimalDisplay');
+    });
+
+    it('rejects precision above 18', async () => {
+      await expect(
+        resolver.mintTapAsset(
+          userId,
+          'TestCoin',
+          '1000',
+          TapAssetType.NORMAL,
+          true,
+          undefined,
+          19
+        )
+      ).rejects.toThrow(GraphQLError);
+      expect(service.mintAsset).not.toHaveBeenCalled();
+    });
+
+    it('rejects negative precision', async () => {
+      await expect(
+        resolver.mintTapAsset(
+          userId,
+          'TestCoin',
+          '1000',
+          TapAssetType.NORMAL,
+          true,
+          undefined,
+          -1
+        )
+      ).rejects.toThrow(GraphQLError);
+      expect(service.mintAsset).not.toHaveBeenCalled();
+    });
   });
 
   describe('finalizeTapBatch', () => {

--- a/src/server/modules/api/tapd/tapd.resolver.spec.ts
+++ b/src/server/modules/api/tapd/tapd.resolver.spec.ts
@@ -581,19 +581,20 @@ describe('TapdResolver', () => {
   });
 
   describe('mintTapAsset', () => {
+    const baseInput = {
+      name: 'TestCoin',
+      amount: '1000',
+      assetType: TapAssetType.NORMAL,
+      grouped: true,
+      precision: 0,
+    };
+
     it('returns batchKey as hex', async () => {
       service.mintAsset.mockResolvedValue({
         pendingBatch: { batchKey: Buffer.from('aabb', 'hex') },
       });
 
-      const result = await resolver.mintTapAsset(
-        userId,
-        'TestCoin',
-        '1000',
-        TapAssetType.NORMAL,
-        true,
-        0
-      );
+      const result = await resolver.mintTapAsset(userId, baseInput);
 
       expect(result.batchKey).toBe('aabb');
     });
@@ -603,14 +604,7 @@ describe('TapdResolver', () => {
         pendingBatch: { batchKey: Buffer.from('aabb', 'hex') },
       });
 
-      await resolver.mintTapAsset(
-        userId,
-        'TestCoin',
-        '1000',
-        TapAssetType.NORMAL,
-        true,
-        2
-      );
+      await resolver.mintTapAsset(userId, { ...baseInput, precision: 2 });
 
       expect(service.mintAsset).toHaveBeenCalledWith(
         expect.objectContaining({ decimalDisplay: 2 })
@@ -619,28 +613,14 @@ describe('TapdResolver', () => {
 
     it('rejects precision above 18', async () => {
       await expect(
-        resolver.mintTapAsset(
-          userId,
-          'TestCoin',
-          '1000',
-          TapAssetType.NORMAL,
-          true,
-          19
-        )
+        resolver.mintTapAsset(userId, { ...baseInput, precision: 19 })
       ).rejects.toThrow(GraphQLError);
       expect(service.mintAsset).not.toHaveBeenCalled();
     });
 
     it('rejects negative precision', async () => {
       await expect(
-        resolver.mintTapAsset(
-          userId,
-          'TestCoin',
-          '1000',
-          TapAssetType.NORMAL,
-          true,
-          -1
-        )
+        resolver.mintTapAsset(userId, { ...baseInput, precision: -1 })
       ).rejects.toThrow(GraphQLError);
       expect(service.mintAsset).not.toHaveBeenCalled();
     });

--- a/src/server/modules/api/tapd/tapd.resolver.ts
+++ b/src/server/modules/api/tapd/tapd.resolver.ts
@@ -318,8 +318,15 @@ export class TapdResolver {
     })
     assetType: TapAssetType,
     @Args('grouped', { nullable: true, defaultValue: true }) grouped: boolean,
-    @Args('groupKey', { nullable: true }) groupKey?: string
+    @Args('groupKey', { nullable: true }) groupKey?: string,
+    @Args('precision', { nullable: true, type: () => Int }) precision?: number
   ) {
+    if (precision != null) {
+      if (!Number.isInteger(precision) || precision < 0 || precision > 18) {
+        throw new GraphQLError('precision must be an integer between 0 and 18');
+      }
+    }
+
     const typeStr =
       assetType === TapAssetType.NORMAL ? 'NORMAL' : 'COLLECTIBLE';
     const [result, error] = await toWithError(
@@ -330,6 +337,7 @@ export class TapdResolver {
         assetType: typeStr,
         grouped,
         groupKey,
+        ...(precision != null ? { decimalDisplay: precision } : {}),
       })
     );
     if (error || !result) {

--- a/src/server/modules/api/tapd/tapd.resolver.ts
+++ b/src/server/modules/api/tapd/tapd.resolver.ts
@@ -26,6 +26,7 @@ import {
   TapAssetInvoiceResponse,
   TapFederationServerList,
   TapFinalizeBatchResponse,
+  TapMintAssetInput,
   TapMintResponse,
   TapFundChannelInput,
   TapFundChannelResponse,
@@ -310,17 +311,10 @@ export class TapdResolver {
   @Mutation(() => TapMintResponse)
   async mintTapAsset(
     @CurrentUser() { id }: UserId,
-    @Args('name') name: string,
-    @Args('amount') amount: string,
-    @Args('assetType', {
-      type: () => TapAssetType,
-      defaultValue: TapAssetType.NORMAL,
-    })
-    assetType: TapAssetType,
-    @Args('grouped', { nullable: true, defaultValue: true }) grouped: boolean,
-    @Args('precision', { type: () => Int }) precision: number,
-    @Args('groupKey', { nullable: true }) groupKey?: string
+    @Args('input') input: TapMintAssetInput
   ) {
+    const { name, amount, assetType, grouped, groupKey, precision } = input;
+
     if (!Number.isInteger(precision) || precision < 0 || precision > 18) {
       throw new GraphQLError('precision must be an integer between 0 and 18');
     }

--- a/src/server/modules/api/tapd/tapd.resolver.ts
+++ b/src/server/modules/api/tapd/tapd.resolver.ts
@@ -318,13 +318,11 @@ export class TapdResolver {
     })
     assetType: TapAssetType,
     @Args('grouped', { nullable: true, defaultValue: true }) grouped: boolean,
-    @Args('groupKey', { nullable: true }) groupKey?: string,
-    @Args('precision', { nullable: true, type: () => Int }) precision?: number
+    @Args('precision', { type: () => Int }) precision: number,
+    @Args('groupKey', { nullable: true }) groupKey?: string
   ) {
-    if (precision != null) {
-      if (!Number.isInteger(precision) || precision < 0 || precision > 18) {
-        throw new GraphQLError('precision must be an integer between 0 and 18');
-      }
+    if (!Number.isInteger(precision) || precision < 0 || precision > 18) {
+      throw new GraphQLError('precision must be an integer between 0 and 18');
     }
 
     const typeStr =
@@ -337,7 +335,7 @@ export class TapdResolver {
         assetType: typeStr,
         grouped,
         groupKey,
-        ...(precision != null ? { decimalDisplay: precision } : {}),
+        decimalDisplay: precision,
       })
     );
     if (error || !result) {

--- a/src/server/modules/api/tapd/tapd.types.ts
+++ b/src/server/modules/api/tapd/tapd.types.ts
@@ -298,6 +298,27 @@ export class TapAssetInvoiceInput {
 }
 
 @InputType()
+export class TapMintAssetInput {
+  @Field()
+  name: string;
+
+  @Field()
+  amount: string;
+
+  @Field(() => Int)
+  precision: number;
+
+  @Field(() => TapAssetType, { defaultValue: TapAssetType.NORMAL })
+  assetType: TapAssetType;
+
+  @Field({ defaultValue: true })
+  grouped: boolean;
+
+  @Field({ nullable: true })
+  groupKey?: string;
+}
+
+@InputType()
 export class TapFundChannelInput {
   @Field()
   peerPubkey: string;

--- a/src/server/modules/node/tapd/tapd-node.service.ts
+++ b/src/server/modules/node/tapd/tapd-node.service.ts
@@ -206,9 +206,9 @@ export class TapdNodeService {
     name: string;
     amount: string;
     assetType: 'NORMAL' | 'COLLECTIBLE';
+    decimalDisplay: number;
     grouped?: boolean;
     groupKey?: string;
-    decimalDisplay?: number;
   }): Promise<MintAssetResponse> {
     const tapd = this.getTapd(opts.id);
     const grouped = opts.grouped ?? true;
@@ -218,9 +218,7 @@ export class TapdNodeService {
         name: opts.name,
         amount: opts.amount,
         assetType: opts.assetType,
-        ...(opts.decimalDisplay != null
-          ? { decimalDisplay: opts.decimalDisplay }
-          : {}),
+        decimalDisplay: opts.decimalDisplay,
         ...(opts.groupKey
           ? {
               groupedAsset: true,

--- a/src/server/modules/node/tapd/tapd-node.service.ts
+++ b/src/server/modules/node/tapd/tapd-node.service.ts
@@ -208,6 +208,7 @@ export class TapdNodeService {
     assetType: 'NORMAL' | 'COLLECTIBLE';
     grouped?: boolean;
     groupKey?: string;
+    decimalDisplay?: number;
   }): Promise<MintAssetResponse> {
     const tapd = this.getTapd(opts.id);
     const grouped = opts.grouped ?? true;
@@ -217,6 +218,9 @@ export class TapdNodeService {
         name: opts.name,
         amount: opts.amount,
         assetType: opts.assetType,
+        ...(opts.decimalDisplay != null
+          ? { decimalDisplay: opts.decimalDisplay }
+          : {}),
         ...(opts.groupKey
           ? {
               groupedAsset: true,


### PR DESCRIPTION
## Summary

- Adds an optional `precision` parameter to the `mintTapAsset` GraphQL mutation that is forwarded to tapd as `decimalDisplay`, letting users set the number of decimal places a minted asset displays in UX.
- Enforces integer bounds (0–18) on both the server resolver and the client form.
- Surfaces a new "Precision (optional)" input on the Mint Asset UI.

## Test plan

- [x] `npm run lint:check`
- [x] `npm run test` (105 passing, includes 4 new tests covering precision passthrough, omission, and range validation)
- [x] `npm run build`
- [ ] Manual: mint a new asset with `precision=2` and verify tapd reports `decimal_display: 2`
- [ ] Manual: omit precision and verify behavior matches previous default
- [ ] Manual: submit `19` or `-1` and verify the server returns a validation error