### PR TITLE
feat: pending channels in trade preview and offer list

### DIFF
--- a/schema.gql
+++ b/schema.gql
@@ -725,6 +725,7 @@ type Peer {
 }
 
 type PendingChannel {
+  asset: ChannelAsset
   close_transaction_id: String
   is_active: Boolean!
   is_closing: Boolean!

--- a/src/client/src/graphql/queries/__generated__/getPendingChannels.generated.tsx
+++ b/src/client/src/graphql/queries/__generated__/getPendingChannels.generated.tsx
@@ -32,6 +32,14 @@ export type GetPendingChannelsQuery = {
       __typename?: 'Node';
       node?: { __typename?: 'NodeType'; alias: string } | null;
     };
+    asset?: {
+      __typename?: 'ChannelAsset';
+      assetId: string;
+      groupKey?: string | null;
+      localBalance: string;
+      remoteBalance: string;
+      capacity: string;
+    } | null;
   }>;
 };
 
@@ -59,6 +67,13 @@ export const GetPendingChannelsDocument = gql`
         node {
           alias
         }
+      }
+      asset {
+        assetId
+        groupKey
+        localBalance
+        remoteBalance
+        capacity
       }
     }
   }

--- a/src/client/src/graphql/queries/getPendingChannels.ts
+++ b/src/client/src/graphql/queries/getPendingChannels.ts
@@ -25,6 +25,13 @@ export const GET_PENDING_CHANNELS = gql`
           alias
         }
       }
+      asset {
+        assetId
+        groupKey
+        localBalance
+        remoteBalance
+        capacity
+      }
     }
   }
 `;

--- a/src/client/src/graphql/types.ts
+++ b/src/client/src/graphql/types.ts
@@ -969,6 +969,7 @@ export type Peer = {
 
 export type PendingChannel = {
   __typename?: 'PendingChannel';
+  asset?: Maybe<ChannelAsset>;
   close_transaction_id?: Maybe<Scalars['String']['output']>;
   is_active: Scalars['Boolean']['output'];
   is_closing: Scalars['Boolean']['output'];

--- a/src/client/src/views/assets/TradeSheet.tsx
+++ b/src/client/src/views/assets/TradeSheet.tsx
@@ -6,6 +6,7 @@ import {
   AlertCircle,
   ArrowRight,
   ArrowLeft,
+  Clock,
 } from 'lucide-react';
 import {
   Sheet,
@@ -21,6 +22,7 @@ import { useSetupTradePartnerMutation } from '../../graphql/mutations/__generate
 import { useOpenChannelMutation } from '../../graphql/mutations/__generated__/openChannel.generated';
 import { useExecuteTradeMutation } from '../../graphql/mutations/__generated__/executeTrade.generated';
 import { useGetPeerChannelsQuery } from '../../graphql/queries/__generated__/getPeerChannels.generated';
+import { useGetPendingChannelsQuery } from '../../graphql/queries/__generated__/getPendingChannels.generated';
 import { useGetTradeQuoteLazyQuery } from '../../graphql/queries/__generated__/getTradeQuote.generated';
 import { getErrorContent } from '../../utils/error';
 import {
@@ -49,6 +51,52 @@ type TradeSheetProps = {
   onOpenChange: (open: boolean) => void;
 };
 
+const PendingChannelCard: FC<{
+  txId: string;
+  capacity: string;
+  local: string;
+  remote: string;
+}> = ({ txId, capacity, local, remote }) => (
+  <div className="flex flex-col gap-0.5 rounded-md border border-blue-500/30 bg-blue-500/5 px-2 py-1.5">
+    <div className="flex justify-between">
+      <span className="text-muted-foreground">{capacity}</span>
+      <span>
+        {local} / {remote}
+      </span>
+    </div>
+    <div className="flex items-center justify-between text-[10px] text-muted-foreground">
+      <span className="font-mono truncate mr-2">{txId}</span>
+      <span className="text-blue-500 flex items-center gap-1 shrink-0">
+        <Clock className="h-3 w-3" />
+        opening
+      </span>
+    </div>
+  </div>
+);
+
+const OpenChannelCard: FC<{
+  channelId: string;
+  capacity: string;
+  local: string;
+  remote: string;
+  isActive: boolean;
+}> = ({ channelId, capacity, local, remote, isActive }) => (
+  <div className="flex flex-col gap-0.5 rounded-md border border-border bg-muted/20 px-2 py-1.5">
+    <div className="flex justify-between">
+      <span className="text-muted-foreground">{capacity}</span>
+      <span>
+        {local} / {remote}
+      </span>
+    </div>
+    <div className="flex items-center justify-between text-[10px] text-muted-foreground">
+      <span className="font-mono">{channelId}</span>
+      <span className={isActive ? 'text-green-500' : 'text-yellow-500'}>
+        {isActive ? 'active' : 'inactive'}
+      </span>
+    </div>
+  </div>
+);
+
 export const TradeSheet: FC<TradeSheetProps> = ({
   offer,
   ambossAssetId,
@@ -69,6 +117,13 @@ export const TradeSheet: FC<TradeSheetProps> = ({
   const [quoteRfqId, setQuoteRfqId] = useState<string | null>(null);
   const [quoteExpiry, setQuoteExpiry] = useState<number | null>(null);
   const [secondsLeft, setSecondsLeft] = useState<number | null>(null);
+
+  const clearQuoteState = () => {
+    setQuotedSats(null);
+    setQuotePaymentRequest(null);
+    setQuoteRfqId(null);
+    setQuoteExpiry(null);
+  };
 
   const [openChannel, { loading: openChannelLoading }] = useOpenChannelMutation(
     {
@@ -103,10 +158,7 @@ export const TradeSheet: FC<TradeSheetProps> = ({
           onOpenChange(false);
           setAmount('');
           setStep('input');
-          setQuotedSats(null);
-          setQuotePaymentRequest(null);
-          setQuoteRfqId(null);
-          setQuoteExpiry(null);
+          clearQuoteState();
         }
       },
       onError: err => toast.error(getErrorContent(err)),
@@ -126,10 +178,7 @@ export const TradeSheet: FC<TradeSheetProps> = ({
         onOpenChange(false);
         setAmount('');
         setStep('input');
-        setQuotedSats(null);
-        setQuotePaymentRequest(null);
-        setQuoteRfqId(null);
-        setQuoteExpiry(null);
+        clearQuoteState();
       } else {
         toast.error('Trade did not complete — please try again');
         setStep('input');
@@ -175,7 +224,72 @@ export const TradeSheet: FC<TradeSheetProps> = ({
       fetchPolicy: 'network-only',
     });
 
+  const { data: pendingData, loading: pendingLoading } =
+    useGetPendingChannelsQuery({
+      skip: !offer?.node.pubkey || !open,
+      fetchPolicy: 'network-only',
+    });
+
+  const matchAsset = (asset: {
+    groupKey?: string | null;
+    assetId: string;
+  }): boolean =>
+    tapdGroupKey
+      ? asset.groupKey === tapdGroupKey
+      : tapdAssetId
+        ? asset.assetId === tapdAssetId
+        : true;
+
+  // Prefill sats amount from existing or pending asset inbound capacity.
+  useEffect(() => {
+    if (!open || !offer?.node.pubkey || amount) return;
+    if (transactionType !== TapTransactionType.Purchase) return;
+
+    const rate = offer.rate.fullAmount;
+    if (!rate || rate === '0') return;
+
+    // Sum inbound from open asset channels
+    const openRemote = (channelsData?.getChannels || [])
+      .filter(ch => ch.asset && matchAsset(ch.asset))
+      .reduce((sum, ch) => sum + BigInt(ch.asset?.remoteBalance || '0'), 0n);
+
+    // Sum capacity from pending asset channels
+    const pendingCap = (pendingData?.getPendingChannels || [])
+      .filter(
+        ch =>
+          ch.is_opening &&
+          ch.partner_public_key === offer.node.pubkey &&
+          ch.asset &&
+          matchAsset(ch.asset)
+      )
+      .reduce((sum, ch) => sum + BigInt(ch.asset?.capacity || '0'), 0n);
+
+    const assetAtomic = openRemote > 0n ? openRemote : pendingCap;
+    if (assetAtomic <= 0n) return;
+
+    const sats = (assetAtomic * BigInt(100_000_000)) / BigInt(rate);
+    if (sats > 0n) setAmount(sats.toString());
+  }, [
+    pendingData,
+    channelsData,
+    open,
+    offer,
+    transactionType,
+    tapdGroupKey,
+    tapdAssetId,
+    amount,
+  ]);
+
   if (!offer) return null;
+
+  const pendingPeerChannels = (pendingData?.getPendingChannels || []).filter(
+    ch => ch.is_opening && ch.partner_public_key === offer.node.pubkey
+  );
+
+  const pendingBtcChannels = pendingPeerChannels.filter(ch => !ch.asset);
+  const pendingAssetChannels = pendingPeerChannels.filter(
+    ch => ch.asset && matchAsset(ch.asset)
+  );
 
   const isAssetPurchase = transactionType === TapTransactionType.Purchase;
   const nodeLabel = offer.node.alias || offer.node.pubkey?.slice(0, 16);
@@ -189,13 +303,9 @@ export const TradeSheet: FC<TradeSheetProps> = ({
   const btcOnlyChannels = peerChannels.filter(ch => !ch.asset);
   const allPeerAssetChannels = peerChannels.filter(ch => ch.asset);
 
-  // Filter to the requested asset. When tapdGroupKey/tapdAssetId is empty,
-  // include all asset channels with this peer.
-  const assetChannels = allPeerAssetChannels.filter(ch => {
-    if (tapdGroupKey) return ch.asset?.groupKey === tapdGroupKey;
-    if (tapdAssetId) return ch.asset?.assetId === tapdAssetId;
-    return true;
-  });
+  const assetChannels = allPeerAssetChannels.filter(
+    ch => ch.asset && matchAsset(ch.asset)
+  );
 
   const totalBtcLocal = btcOnlyChannels.reduce(
     (sum, ch) => sum + ch.local_balance,
@@ -203,11 +313,11 @@ export const TradeSheet: FC<TradeSheetProps> = ({
   );
   const totalAssetLocal = assetChannels.reduce(
     (sum, ch) => sum + BigInt(ch.asset?.localBalance || '0'),
-    BigInt(0)
+    0n
   );
   const totalAssetRemote = assetChannels.reduce(
     (sum, ch) => sum + BigInt(ch.asset?.remoteBalance || '0'),
-    BigInt(0)
+    0n
   );
   const totalBtcRemote = btcOnlyChannels.reduce(
     (sum, ch) => sum + ch.remote_balance,
@@ -216,11 +326,27 @@ export const TradeSheet: FC<TradeSheetProps> = ({
 
   const isValid = amount && BigInt(amount) > 0n;
 
+  const hasPendingOutbound = isAssetPurchase
+    ? pendingBtcChannels.length > 0
+    : pendingAssetChannels.length > 0;
+
+  const hasPendingInbound = isAssetPurchase
+    ? pendingAssetChannels.length > 0
+    : pendingBtcChannels.length > 0;
+
+  const pendingOutboundSats = pendingBtcChannels.reduce(
+    (sum, ch) => sum + (ch.local_balance || 0) + (ch.remote_balance || 0),
+    0
+  );
+
   // Determine input mode from raw capacity to avoid circular dependency.
-  // When buying with existing asset inbound but no BTC outbound, the user
-  // opens a direct BTC channel (amount = sats) instead of a Magma order.
+  // When buying with existing or pending asset inbound but no BTC outbound,
+  // the user opens a direct BTC channel (amount = sats) instead of a Magma order.
   const needsOnlyOutboundBtc =
-    isAssetPurchase && totalAssetRemote > BigInt(0) && !(totalBtcLocal > 0);
+    isAssetPurchase &&
+    (totalAssetRemote > 0n || hasPendingInbound) &&
+    !(totalBtcLocal > 0) &&
+    !hasPendingOutbound;
 
   // Input is asset display units unless needsOnlyOutboundBtc (sats directly).
   // rate is in atomic-asset-units per BTC (full_amount from trade API)
@@ -232,7 +358,7 @@ export const TradeSheet: FC<TradeSheetProps> = ({
   const atomicTradeAmount =
     isValid && !needsOnlyOutboundBtc
       ? displayToAtomic(amount, assetPrecision)
-      : BigInt(0);
+      : 0n;
 
   // Amount-aware capacity checks: passes only if existing channels cover the
   // requested trade size. Falls back to > 0 when no amount has been entered.
@@ -244,7 +370,7 @@ export const TradeSheet: FC<TradeSheetProps> = ({
         : totalAssetLocal >= atomicTradeAmount
       : isAssetPurchase
         ? totalBtcLocal > 0
-        : totalAssetLocal > BigInt(0);
+        : totalAssetLocal > 0n;
 
   const hasInbound = needsOnlyOutboundBtc
     ? true
@@ -253,7 +379,7 @@ export const TradeSheet: FC<TradeSheetProps> = ({
         ? totalAssetRemote >= atomicTradeAmount
         : totalBtcRemote >= Number(satsAmount)
       : isAssetPurchase
-        ? totalAssetRemote > BigInt(0)
+        ? totalAssetRemote > 0n
         : totalBtcRemote > 0;
 
   const readyToTrade = hasOutbound && hasInbound;
@@ -283,6 +409,27 @@ export const TradeSheet: FC<TradeSheetProps> = ({
   const magmaSize = isAssetPurchase ? amount : satsAmount;
   const magmaUnit = isAssetPurchase ? assetSymbol : 'sats';
 
+  // Amount-independent: do both channel types exist (open or pending)?
+  const outboundExists = isAssetPurchase
+    ? totalBtcLocal > 0 || hasPendingOutbound
+    : totalAssetLocal > 0n || hasPendingOutbound;
+  const inboundExists = isAssetPurchase
+    ? totalAssetRemote > 0n || hasPendingInbound
+    : totalBtcRemote > 0 || hasPendingInbound;
+  const allChannelsExist = outboundExists && inboundExists;
+
+  // Only suppress the input when channels are still pending. If all channels
+  // are open but balance is insufficient, the user can still adjust the amount.
+  const hasPendingChannels = pendingPeerChannels.length > 0;
+  const waitingForChannels =
+    allChannelsExist && !readyToTrade && hasPendingChannels;
+
+  // Whether to hide the outbound card on the confirm step (already covered).
+  const skipOutboundCard =
+    hasOutbound ||
+    (hasPendingOutbound &&
+      (!isValid || pendingOutboundSats >= Number(satsAmount)));
+
   const handleSubmit = () => {
     if (!amount || !offer.node.pubkey) return;
 
@@ -298,9 +445,12 @@ export const TradeSheet: FC<TradeSheetProps> = ({
       return;
     }
 
-    // When outbound already exists we skip opening a BTC channel by omitting satsAmount.
+    // Skip opening a BTC channel when outbound is already sufficient (open)
+    // or a pending channel covers the needed capacity.
     const skipOutboundBtc =
-      isAssetPurchase && hasInbound === false && hasOutbound === true;
+      isAssetPurchase &&
+      (hasOutbound ||
+        (hasPendingOutbound && pendingOutboundSats >= Number(satsAmount)));
 
     setupPartner({
       variables: {
@@ -322,11 +472,8 @@ export const TradeSheet: FC<TradeSheetProps> = ({
 
   const handleReviewTrade = async () => {
     if (!amount || !offer.node.pubkey) return;
-    setQuotedSats(null);
-    setQuotePaymentRequest(null);
-    setQuoteRfqId(null);
-    setQuoteExpiry(null);
-    const assetAtomicAmount = String(displayToAtomic(amount, assetPrecision));
+    clearQuoteState();
+    const assetAtomicAmount = atomicTradeAmount.toString();
     const { data, error } = await fetchQuote({
       variables: {
         input: {
@@ -371,13 +518,12 @@ export const TradeSheet: FC<TradeSheetProps> = ({
       );
       return;
     }
-    const assetAtomicAmount = String(displayToAtomic(amount, assetPrecision));
     executeTrade({
       variables: {
         input: {
           tapdAssetId,
           tapdGroupKey: tapdGroupKey || undefined,
-          assetAmount: assetAtomicAmount,
+          assetAmount: atomicTradeAmount.toString(),
           satsAmount: displaySats,
           transactionType,
           peerPubkey: offer.node.pubkey,
@@ -388,20 +534,13 @@ export const TradeSheet: FC<TradeSheetProps> = ({
     });
   };
 
-  const clearQuoteState = () => {
-    setQuotedSats(null);
-    setQuotePaymentRequest(null);
-    setQuoteRfqId(null);
-    setQuoteExpiry(null);
-  };
-
-  const handleOpenChange = (open: boolean) => {
-    if (!open) {
+  const handleOpenChange = (nextOpen: boolean) => {
+    if (!nextOpen) {
       setStep('input');
       setAmount('');
       clearQuoteState();
     }
-    onOpenChange(open);
+    onOpenChange(nextOpen);
   };
 
   return (
@@ -454,119 +593,130 @@ export const TradeSheet: FC<TradeSheetProps> = ({
             {/* Existing channels with peer */}
             <div className="flex flex-col gap-2">
               <span className="text-sm font-medium">Existing channels</span>
-              {channelsLoading ? (
+              {channelsLoading || pendingLoading ? (
                 <div className="flex items-center gap-2 text-xs text-muted-foreground">
                   <Loader2 className="h-3 w-3 animate-spin" />
                   Checking channels...
                 </div>
-              ) : btcOnlyChannels.length === 0 && assetChannels.length === 0 ? (
+              ) : btcOnlyChannels.length === 0 &&
+                assetChannels.length === 0 &&
+                pendingBtcChannels.length === 0 &&
+                pendingAssetChannels.length === 0 ? (
                 <div className="text-xs text-muted-foreground">
                   No channels with this node
                 </div>
               ) : (
                 <div className="flex flex-col gap-1 text-xs">
+                  {pendingBtcChannels.map(ch => (
+                    <PendingChannelCard
+                      key={ch.transaction_id}
+                      txId={ch.transaction_id}
+                      capacity={`${((ch.local_balance || 0) + (ch.remote_balance || 0)).toLocaleString()} sats`}
+                      local={(ch.local_balance || 0).toLocaleString()}
+                      remote={(ch.remote_balance || 0).toLocaleString()}
+                    />
+                  ))}
+                  {pendingAssetChannels.map(ch => (
+                    <PendingChannelCard
+                      key={ch.transaction_id}
+                      txId={ch.transaction_id}
+                      capacity={`${atomicToDisplay(ch.asset!.capacity, assetPrecision)} ${assetSymbol}`}
+                      local={atomicToDisplay(
+                        ch.asset!.localBalance,
+                        assetPrecision
+                      )}
+                      remote={atomicToDisplay(
+                        ch.asset!.remoteBalance,
+                        assetPrecision
+                      )}
+                    />
+                  ))}
                   {btcOnlyChannels.map(ch => (
-                    <div
+                    <OpenChannelCard
                       key={ch.id}
-                      className="flex flex-col gap-0.5 rounded-md border border-border bg-muted/20 px-2 py-1.5"
-                    >
-                      <div className="flex justify-between">
-                        <span className="text-muted-foreground">
-                          {Number(ch.capacity).toLocaleString()} sats
-                        </span>
-                        <span>
-                          {Number(ch.local_balance).toLocaleString()} /{' '}
-                          {Number(ch.remote_balance).toLocaleString()}
-                        </span>
-                      </div>
-                      <div className="flex items-center justify-between text-[10px] text-muted-foreground">
-                        <span className="font-mono">{ch.id}</span>
-                        <span
-                          className={
-                            ch.is_active ? 'text-green-500' : 'text-yellow-500'
-                          }
-                        >
-                          {ch.is_active ? 'active' : 'inactive'}
-                        </span>
-                      </div>
-                    </div>
+                      channelId={ch.id}
+                      capacity={`${Number(ch.capacity).toLocaleString()} sats`}
+                      local={Number(ch.local_balance).toLocaleString()}
+                      remote={Number(ch.remote_balance).toLocaleString()}
+                      isActive={ch.is_active}
+                    />
                   ))}
                   {assetChannels.map(ch => (
-                    <div
+                    <OpenChannelCard
                       key={ch.id}
-                      className="flex flex-col gap-0.5 rounded-md border border-border bg-muted/20 px-2 py-1.5"
-                    >
-                      <div className="flex justify-between">
-                        <span className="text-muted-foreground">
-                          {atomicToDisplay(ch.asset!.capacity, assetPrecision)}{' '}
-                          {assetSymbol}
-                        </span>
-                        <span>
-                          {atomicToDisplay(
-                            ch.asset!.localBalance,
-                            assetPrecision
-                          )}{' '}
-                          /{' '}
-                          {atomicToDisplay(
-                            ch.asset!.remoteBalance,
-                            assetPrecision
-                          )}
-                        </span>
-                      </div>
-                      <div className="flex items-center justify-between text-[10px] text-muted-foreground">
-                        <span className="font-mono">{ch.id}</span>
-                        <span
-                          className={
-                            ch.is_active ? 'text-green-500' : 'text-yellow-500'
-                          }
-                        >
-                          {ch.is_active ? 'active' : 'inactive'}
-                        </span>
-                      </div>
-                    </div>
+                      channelId={ch.id}
+                      capacity={`${atomicToDisplay(ch.asset!.capacity, assetPrecision)} ${assetSymbol}`}
+                      local={atomicToDisplay(
+                        ch.asset!.localBalance,
+                        assetPrecision
+                      )}
+                      remote={atomicToDisplay(
+                        ch.asset!.remoteBalance,
+                        assetPrecision
+                      )}
+                      isActive={ch.is_active}
+                    />
                   ))}
                 </div>
               )}
             </div>
 
             {/* Channel status */}
-            {!channelsLoading && (
+            {!channelsLoading && !pendingLoading && (
               <div className="flex flex-col gap-1.5">
                 <span className="text-sm font-medium">Channel status</span>
                 <div className="flex flex-col gap-1 text-xs">
+                  {pendingPeerChannels.length > 0 && (
+                    <div className="flex items-center gap-2">
+                      <Clock className="h-3.5 w-3.5 text-blue-500" />
+                      <span className="text-blue-500">
+                        {pendingPeerChannels.length} channel
+                        {pendingPeerChannels.length > 1 ? 's' : ''} opening with
+                        this node
+                      </span>
+                    </div>
+                  )}
                   <div className="flex items-center gap-2">
-                    {hasOutbound ? (
+                    {outboundExists && !hasPendingOutbound ? (
                       <CheckCircle2 className="h-3.5 w-3.5 text-green-500" />
+                    ) : hasPendingOutbound ? (
+                      <Clock className="h-3.5 w-3.5 text-blue-500" />
                     ) : (
                       <AlertCircle className="h-3.5 w-3.5 text-yellow-500" />
                     )}
                     <span>
                       Outbound ({isAssetPurchase ? 'BTC' : assetSymbol})
-                      {hasOutbound ? (
+                      {outboundExists && !hasPendingOutbound ? (
                         <span className="text-muted-foreground ml-1">
                           {isAssetPurchase
                             ? `${totalBtcLocal.toLocaleString()} sats`
                             : `${atomicToDisplay(totalAssetLocal.toString(), assetPrecision)} ${assetSymbol}`}
                         </span>
+                      ) : hasPendingOutbound ? (
+                        <span className="text-blue-500 ml-1">opening</span>
                       ) : (
                         <span className="text-yellow-500 ml-1">missing</span>
                       )}
                     </span>
                   </div>
                   <div className="flex items-center gap-2">
-                    {hasInbound ? (
+                    {inboundExists && !hasPendingInbound ? (
                       <CheckCircle2 className="h-3.5 w-3.5 text-green-500" />
+                    ) : hasPendingInbound ? (
+                      <Clock className="h-3.5 w-3.5 text-blue-500" />
                     ) : (
                       <AlertCircle className="h-3.5 w-3.5 text-yellow-500" />
                     )}
                     <span>
                       Inbound ({isAssetPurchase ? assetSymbol : 'BTC'})
-                      {hasInbound ? (
+                      {inboundExists && !hasPendingInbound ? (
                         <span className="text-muted-foreground ml-1">
                           {isAssetPurchase
                             ? `${atomicToDisplay(totalAssetRemote.toString(), assetPrecision)} ${assetSymbol}`
                             : `${totalBtcRemote.toLocaleString()} sats`}
                         </span>
+                      ) : hasPendingInbound ? (
+                        <span className="text-blue-500 ml-1">opening</span>
                       ) : (
                         <span className="text-yellow-500 ml-1">
                           missing — will be purchased via Magma
@@ -578,39 +728,46 @@ export const TradeSheet: FC<TradeSheetProps> = ({
               </div>
             )}
 
-            <div className="flex flex-col gap-1.5">
-              <label
-                htmlFor="trade-amount"
-                className="text-sm text-muted-foreground"
-              >
-                {needsOnlyOutboundBtc
-                  ? 'Channel size (sats)'
-                  : `Amount (${assetSymbol})`}
-              </label>
-              <div className="relative">
-                <input
-                  id="trade-amount"
-                  type="text"
-                  inputMode="decimal"
-                  placeholder="Enter amount"
-                  value={amount}
-                  onChange={e => {
-                    const v = e.target.value.replace(/[^0-9.]/g, '');
-                    // Allow only one decimal point
-                    const parts = v.split('.');
-                    setAmount(
-                      parts.length > 2
-                        ? `${parts[0]}.${parts.slice(1).join('')}`
-                        : v
-                    );
-                  }}
-                  className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm pr-16"
-                />
-                <span className="absolute right-3 top-1/2 -translate-y-1/2 text-xs text-muted-foreground">
-                  {needsOnlyOutboundBtc ? 'sats' : assetSymbol}
-                </span>
+            {waitingForChannels ? (
+              <div className="rounded-md border border-blue-500/30 bg-blue-500/5 p-3 text-sm text-blue-500">
+                All channels are in place. Trade will be available once pending
+                channels confirm.
               </div>
-            </div>
+            ) : (
+              <div className="flex flex-col gap-1.5">
+                <label
+                  htmlFor="trade-amount"
+                  className="text-sm text-muted-foreground"
+                >
+                  {needsOnlyOutboundBtc
+                    ? 'Channel size (sats)'
+                    : `Amount (${assetSymbol})`}
+                </label>
+                <div className="relative">
+                  <input
+                    id="trade-amount"
+                    type="text"
+                    inputMode="decimal"
+                    placeholder="Enter amount"
+                    value={amount}
+                    onChange={e => {
+                      const v = e.target.value.replace(/[^0-9.]/g, '');
+                      // Allow only one decimal point
+                      const parts = v.split('.');
+                      setAmount(
+                        parts.length > 2
+                          ? `${parts[0]}.${parts.slice(1).join('')}`
+                          : v
+                      );
+                    }}
+                    className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm pr-16"
+                  />
+                  <span className="absolute right-3 top-1/2 -translate-y-1/2 text-xs text-muted-foreground">
+                    {needsOnlyOutboundBtc ? 'sats' : assetSymbol}
+                  </span>
+                </div>
+              </div>
+            )}
           </div>
         )}
 
@@ -700,7 +857,7 @@ export const TradeSheet: FC<TradeSheetProps> = ({
               <div className="flex flex-col gap-2">
                 <span className="text-sm font-medium">Channels to open</span>
                 <div className="flex flex-col gap-2">
-                  {!hasOutbound && (
+                  {!skipOutboundCard && (
                     <div className="rounded-md border border-border bg-muted/20 p-3">
                       <div className="flex items-center gap-2 text-xs text-muted-foreground mb-1">
                         <ArrowRight className="h-3.5 w-3.5" />
@@ -714,7 +871,7 @@ export const TradeSheet: FC<TradeSheetProps> = ({
                       </div>
                     </div>
                   )}
-                  {!hasInbound && (
+                  {!hasInbound && !hasPendingInbound && (
                     <div className="rounded-md border border-border bg-muted/20 p-3">
                       <div className="flex items-center gap-2 text-xs text-muted-foreground mb-1">
                         <ArrowLeft className="h-3.5 w-3.5" />
@@ -735,7 +892,7 @@ export const TradeSheet: FC<TradeSheetProps> = ({
         )}
 
         <SheetFooter className="flex-row gap-2 p-4">
-          {step === 'input' && (
+          {step === 'input' && !waitingForChannels && (
             <Button
               onClick={
                 readyToTrade ? handleReviewTrade : () => setStep('confirm')
@@ -800,7 +957,7 @@ export const TradeSheet: FC<TradeSheetProps> = ({
                 <Button
                   size="lg"
                   onClick={handleSubmit}
-                  disabled={loading}
+                  disabled={loading || waitingForChannels}
                   className="flex-1"
                 >
                   {loading ? (
@@ -808,6 +965,8 @@ export const TradeSheet: FC<TradeSheetProps> = ({
                       <Loader2 className="mr-2 h-4 w-4 animate-spin" />
                       {needsOnlyOutboundBtc ? 'Opening...' : 'Setting up...'}
                     </>
+                  ) : waitingForChannels ? (
+                    'Channels opening...'
                   ) : needsOnlyOutboundBtc ? (
                     'Open Channel'
                   ) : (

--- a/src/client/src/views/assets/TradeSheet.tsx
+++ b/src/client/src/views/assets/TradeSheet.tsx
@@ -238,7 +238,7 @@ export const TradeSheet: FC<TradeSheetProps> = ({
       ? asset.groupKey === tapdGroupKey
       : tapdAssetId
         ? asset.assetId === tapdAssetId
-        : true;
+        : false;
 
   // Prefill sats amount from existing or pending asset inbound capacity.
   useEffect(() => {
@@ -335,7 +335,7 @@ export const TradeSheet: FC<TradeSheetProps> = ({
     : pendingBtcChannels.length > 0;
 
   const pendingOutboundSats = pendingBtcChannels.reduce(
-    (sum, ch) => sum + (ch.local_balance || 0) + (ch.remote_balance || 0),
+    (sum, ch) => sum + (ch.local_balance || 0),
     0
   );
 

--- a/src/client/src/views/assets/TradingOffers.tsx
+++ b/src/client/src/views/assets/TradingOffers.tsx
@@ -7,6 +7,7 @@ import {
   Zap,
   CheckCircle2,
   Circle,
+  Clock,
   ChevronRight,
 } from 'lucide-react';
 import { useGetTapOffersQuery } from '../../graphql/queries/__generated__/getTapOffers.generated';
@@ -14,6 +15,7 @@ import { useGetTapSupportedAssetsQuery } from '../../graphql/queries/__generated
 import { useGetTapBalancesQuery } from '../../graphql/queries/__generated__/getTapBalances.generated';
 import { useGetChannelsWithPeersQuery } from '../../graphql/queries/__generated__/getChannels.generated';
 import { useGetTapAssetChannelBalancesQuery } from '../../graphql/queries/__generated__/getTapAssetChannelBalances.generated';
+import { useGetPendingChannelsQuery } from '../../graphql/queries/__generated__/getPendingChannels.generated';
 import { getErrorContent } from '../../utils/error';
 import { cn } from '../../lib/utils';
 import {
@@ -29,6 +31,21 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from '@/components/ui/tooltip';
+
+type ChannelStatus = { hasBtc: boolean; hasAsset: boolean; pending: boolean };
+
+const SortIcon: FC<{
+  field: TapOfferSortBy;
+  activeSortBy: TapOfferSortBy;
+}> = ({ field, activeSortBy }) => (
+  <ArrowUpDown
+    size={12}
+    className={cn(
+      'inline ml-1',
+      activeSortBy === field ? 'text-foreground' : 'text-muted-foreground/40'
+    )}
+  />
+);
 
 export const TradingOffers: FC = () => {
   const [selectedOffer, setSelectedOffer] = useState<Offer | null>(null);
@@ -59,6 +76,7 @@ export const TradingOffers: FC = () => {
     variables: { active: true },
   });
   const { data: allAssetChannelsData } = useGetTapAssetChannelBalancesQuery();
+  const { data: pendingData } = useGetPendingChannelsQuery();
 
   const allSupported =
     supportedData?.rails?.get_tap_supported_assets?.list || [];
@@ -147,28 +165,77 @@ export const TradingOffers: FC = () => {
   const selectedTapdAssetId = selectedAssetData?.assetId || '';
   const selectedTapdGroupKey = selectedAssetData?.groupKey || '';
 
+  const assetPeersForSelectedAsset = useMemo(
+    () =>
+      selectedTapdGroupKey
+        ? assetChannelsByGroupKey.get(selectedTapdGroupKey)
+        : selectedTapdAssetId
+          ? assetChannelsByAssetId.get(selectedTapdAssetId)
+          : undefined,
+    [
+      selectedTapdGroupKey,
+      selectedTapdAssetId,
+      assetChannelsByGroupKey,
+      assetChannelsByAssetId,
+    ]
+  );
+
+  // Per-pubkey channel status for the selected asset
+  const channelStatusByPubkey = useMemo(() => {
+    const map = new Map<string, ChannelStatus>();
+
+    const ensure = (pk: string) => {
+      if (!map.has(pk))
+        map.set(pk, { hasBtc: false, hasAsset: false, pending: false });
+      return map.get(pk)!;
+    };
+
+    for (const pk of btcChannelPubkeys) {
+      ensure(pk).hasBtc = true;
+    }
+
+    for (const pk of assetPeersForSelectedAsset || []) {
+      ensure(pk).hasAsset = true;
+    }
+
+    for (const ch of pendingData?.getPendingChannels || []) {
+      if (!ch.is_opening) continue;
+      const s = ensure(ch.partner_public_key);
+      if (ch.asset) {
+        const match = selectedTapdGroupKey
+          ? ch.asset.groupKey === selectedTapdGroupKey
+          : selectedTapdAssetId
+            ? ch.asset.assetId === selectedTapdAssetId
+            : false;
+        if (match) {
+          s.hasAsset = true;
+          s.pending = true;
+        }
+      } else {
+        s.hasBtc = true;
+        s.pending = true;
+      }
+    }
+
+    return map;
+  }, [
+    btcChannelPubkeys,
+    assetPeersForSelectedAsset,
+    selectedTapdAssetId,
+    selectedTapdGroupKey,
+    pendingData,
+  ]);
+
   // Find trading partners: peers with both BTC + asset channels for selected asset
   const tradingPartners = useMemo(() => {
-    const assetPeers = selectedTapdGroupKey
-      ? assetChannelsByGroupKey.get(selectedTapdGroupKey)
-      : selectedTapdAssetId
-        ? assetChannelsByAssetId.get(selectedTapdAssetId)
-        : undefined;
-    if (!assetPeers) return [];
-    return Array.from(assetPeers)
+    if (!assetPeersForSelectedAsset) return [];
+    return Array.from(assetPeersForSelectedAsset)
       .filter(pubkey => btcChannelPubkeys.has(pubkey))
       .map(pubkey => ({
         pubkey,
         alias: aliasMap.get(pubkey) || null,
       }));
-  }, [
-    selectedTapdAssetId,
-    selectedTapdGroupKey,
-    assetChannelsByAssetId,
-    assetChannelsByGroupKey,
-    btcChannelPubkeys,
-    aliasMap,
-  ]);
+  }, [assetPeersForSelectedAsset, btcChannelPubkeys, aliasMap]);
 
   const {
     data: offersData,
@@ -211,16 +278,6 @@ export const TradingOffers: FC = () => {
       available: { displayAmount: null, fullAmount: null },
     });
   };
-
-  const SortIcon: FC<{ field: TapOfferSortBy }> = ({ field }) => (
-    <ArrowUpDown
-      size={12}
-      className={cn(
-        'inline ml-1',
-        sortBy === field ? 'text-foreground' : 'text-muted-foreground/40'
-      )}
-    />
-  );
 
   return (
     <div className="flex flex-col gap-4">
@@ -377,7 +434,7 @@ export const TradingOffers: FC = () => {
         </div>
       )}
 
-      {/* Trade amount input */}
+      {/* Minimum amount filter */}
       {selectedAsset && (
         <div className="flex items-center gap-2">
           <div className="relative flex-1">
@@ -447,48 +504,88 @@ export const TradingOffers: FC = () => {
                   onClick={() => toggleSort(TapOfferSortBy.Rate)}
                 >
                   {selectedSymbol ? `${selectedSymbol}/BTC` : 'Rate'}
-                  <SortIcon field={TapOfferSortBy.Rate} />
+                  <SortIcon field={TapOfferSortBy.Rate} activeSortBy={sortBy} />
                 </th>
                 <th
                   className="text-left py-3 px-3 font-medium cursor-pointer select-none"
                   onClick={() => toggleSort(TapOfferSortBy.Available)}
                 >
                   Available
-                  <SortIcon field={TapOfferSortBy.Available} />
+                  <SortIcon
+                    field={TapOfferSortBy.Available}
+                    activeSortBy={sortBy}
+                  />
                 </th>
+                <th className="text-left py-3 px-3 font-medium">Channels</th>
                 <th className="py-3 px-3 w-8" />
               </tr>
             </thead>
             <tbody>
-              {offers.map(offer => (
-                <tr
-                  key={offer.id}
-                  className="border-b border-border/50 hover:bg-muted/30 transition-colors cursor-pointer"
-                  onClick={() => setSelectedOffer(offer)}
-                >
-                  <td className="py-3 px-3 font-mono text-xs">
-                    {offer.node.alias || offer.node.pubkey?.slice(0, 16)}
-                  </td>
-                  <td className="py-3 px-3">
-                    {offer.rate.displayAmount || offer.rate.fullAmount}
-                  </td>
-                  <td className="py-3 px-3">
-                    {Number(
-                      offer.available.displayAmount ||
-                        offer.available.fullAmount ||
-                        0
-                    ).toLocaleString()}
-                    {selectedSymbol && (
-                      <span className="text-muted-foreground ml-1">
-                        {selectedSymbol}
-                      </span>
-                    )}
-                  </td>
-                  <td className="py-3 px-3 text-muted-foreground/50">
-                    <ChevronRight size={14} />
-                  </td>
-                </tr>
-              ))}
+              {offers.map(offer => {
+                const status = offer.node.pubkey
+                  ? channelStatusByPubkey.get(offer.node.pubkey)
+                  : undefined;
+                return (
+                  <tr
+                    key={offer.id}
+                    className="border-b border-border/50 hover:bg-muted/30 transition-colors cursor-pointer"
+                    onClick={() => setSelectedOffer(offer)}
+                  >
+                    <td className="py-3 px-3 font-mono text-xs">
+                      {offer.node.alias || offer.node.pubkey?.slice(0, 16)}
+                    </td>
+                    <td className="py-3 px-3">
+                      {offer.rate.displayAmount || offer.rate.fullAmount}
+                    </td>
+                    <td className="py-3 px-3">
+                      {Number(
+                        offer.available.displayAmount ||
+                          offer.available.fullAmount ||
+                          0
+                      ).toLocaleString()}
+                      {selectedSymbol && (
+                        <span className="text-muted-foreground ml-1">
+                          {selectedSymbol}
+                        </span>
+                      )}
+                    </td>
+                    <td className="py-3 px-3">
+                      {status ? (
+                        <div className="flex items-center gap-1.5 text-[10px]">
+                          <span
+                            className={
+                              status.hasBtc
+                                ? 'text-green-500'
+                                : 'text-muted-foreground/40'
+                            }
+                          >
+                            BTC
+                          </span>
+                          <span
+                            className={
+                              status.hasAsset
+                                ? 'text-green-500'
+                                : 'text-muted-foreground/40'
+                            }
+                          >
+                            {selectedSymbol || 'Asset'}
+                          </span>
+                          {status.pending && (
+                            <Clock size={10} className="text-blue-500" />
+                          )}
+                        </div>
+                      ) : (
+                        <span className="text-[10px] text-muted-foreground/40">
+                          none
+                        </span>
+                      )}
+                    </td>
+                    <td className="py-3 px-3 text-muted-foreground/50">
+                      <ChevronRight size={14} />
+                    </td>
+                  </tr>
+                );
+              })}
             </tbody>
           </table>
           {totalCount > offers.length && (

--- a/src/client/src/views/assets/TradingOffers.tsx
+++ b/src/client/src/views/assets/TradingOffers.tsx
@@ -32,7 +32,10 @@ import {
   TooltipTrigger,
 } from '@/components/ui/tooltip';
 
-type ChannelStatus = { hasBtc: boolean; hasAsset: boolean; pending: boolean };
+type ChannelStatus = {
+  btc: 'none' | 'pending' | 'open';
+  asset: 'none' | 'pending' | 'open';
+};
 
 const SortIcon: FC<{
   field: TapOfferSortBy;
@@ -185,17 +188,16 @@ export const TradingOffers: FC = () => {
     const map = new Map<string, ChannelStatus>();
 
     const ensure = (pk: string) => {
-      if (!map.has(pk))
-        map.set(pk, { hasBtc: false, hasAsset: false, pending: false });
+      if (!map.has(pk)) map.set(pk, { btc: 'none', asset: 'none' });
       return map.get(pk)!;
     };
 
     for (const pk of btcChannelPubkeys) {
-      ensure(pk).hasBtc = true;
+      ensure(pk).btc = 'open';
     }
 
     for (const pk of assetPeersForSelectedAsset || []) {
-      ensure(pk).hasAsset = true;
+      ensure(pk).asset = 'open';
     }
 
     for (const ch of pendingData?.getPendingChannels || []) {
@@ -207,13 +209,11 @@ export const TradingOffers: FC = () => {
           : selectedTapdAssetId
             ? ch.asset.assetId === selectedTapdAssetId
             : false;
-        if (match) {
-          s.hasAsset = true;
-          s.pending = true;
+        if (match && s.asset === 'none') {
+          s.asset = 'pending';
         }
-      } else {
-        s.hasBtc = true;
-        s.pending = true;
+      } else if (s.btc === 'none') {
+        s.btc = 'pending';
       }
     }
 
@@ -554,24 +554,29 @@ export const TradingOffers: FC = () => {
                         <div className="flex items-center gap-1.5 text-[10px]">
                           <span
                             className={
-                              status.hasBtc
+                              status.btc === 'open'
                                 ? 'text-green-500'
-                                : 'text-muted-foreground/40'
+                                : status.btc === 'pending'
+                                  ? 'text-yellow-500'
+                                  : 'text-muted-foreground/40'
                             }
                           >
                             BTC
                           </span>
                           <span
                             className={
-                              status.hasAsset
+                              status.asset === 'open'
                                 ? 'text-green-500'
-                                : 'text-muted-foreground/40'
+                                : status.asset === 'pending'
+                                  ? 'text-yellow-500'
+                                  : 'text-muted-foreground/40'
                             }
                           >
                             {selectedSymbol || 'Asset'}
                           </span>
-                          {status.pending && (
-                            <Clock size={10} className="text-blue-500" />
+                          {(status.btc === 'pending' ||
+                            status.asset === 'pending') && (
+                            <Clock size={10} className="text-yellow-500" />
                           )}
                         </div>
                       ) : (

--- a/src/server/modules/api/channels/channels.resolver.ts
+++ b/src/server/modules/api/channels/channels.resolver.ts
@@ -24,6 +24,22 @@ import { GetRecommendedNode } from '../amboss/amboss.gql';
 import { AmbossService } from '../amboss/amboss.service';
 import { TapdNodeService } from '../../node/tapd/tapd-node.service';
 
+function toAssetField(ac: {
+  assetId: string;
+  groupKey: string;
+  localBalance: string;
+  remoteBalance: string;
+  capacity: string;
+}) {
+  return {
+    assetId: ac.assetId,
+    groupKey: ac.groupKey,
+    localBalance: ac.localBalance,
+    remoteBalance: ac.remoteBalance,
+    capacity: ac.capacity,
+  };
+}
+
 @Resolver()
 export class ChannelsResolver {
   constructor(
@@ -98,17 +114,7 @@ export class ChannelsResolver {
         partner_fee_info: { localKey: public_key },
         channel_age: getChannelAge(channel.id, current_block_height),
         partner_node_info: { publicKey: channel.partner_public_key },
-        ...(asset
-          ? {
-              asset: {
-                assetId: asset.assetId,
-                groupKey: asset.groupKey,
-                localBalance: asset.localBalance,
-                remoteBalance: asset.remoteBalance,
-                capacity: asset.capacity,
-              },
-            }
-          : {}),
+        ...(asset ? { asset: toAssetField(asset) } : {}),
       };
     });
   }
@@ -135,10 +141,23 @@ export class ChannelsResolver {
   async getPendingChannels(@CurrentUser() { id }: UserId) {
     const { pending_channels } = await this.nodeService.getPendingChannels(id);
 
-    return pending_channels.map(channel => ({
-      ...channel,
-      partner_node_info: { publicKey: channel.partner_public_key },
-    }));
+    const [assetChannels] = await toWithError(
+      this.tapdNodeService.getPendingAssetChannels({ id })
+    );
+
+    const assetByChannelPoint = new Map(
+      (assetChannels || []).map(ac => [ac.channelPoint, ac])
+    );
+
+    return pending_channels.map(channel => {
+      const channelPoint = `${channel.transaction_id}:${channel.transaction_vout}`;
+      const asset = assetByChannelPoint.get(channelPoint);
+      return {
+        ...channel,
+        partner_node_info: { publicKey: channel.partner_public_key },
+        ...(asset ? { asset: toAssetField(asset) } : {}),
+      };
+    });
   }
 
   @Mutation(() => OpenOrCloseChannel)

--- a/src/server/modules/api/channels/channels.types.ts
+++ b/src/server/modules/api/channels/channels.types.ts
@@ -249,6 +249,8 @@ export class PendingChannel {
   timelock_blocks: number;
   @Field({ nullable: true })
   timelock_expiration: number;
+  @Field(() => ChannelAsset, { nullable: true })
+  asset?: ChannelAsset;
 }
 
 @ObjectType()

--- a/src/server/modules/node/tapd/tapd-node.service.ts
+++ b/src/server/modules/node/tapd/tapd-node.service.ts
@@ -37,6 +37,16 @@ import { ProviderRegistryService } from '../provider-registry.service';
 import { Capability } from '../lightning.types';
 import { isTaprootAssetsProvider } from './taproot-assets.types';
 
+type AssetChannelInfo = {
+  channelPoint: string;
+  partnerPublicKey: string;
+  assetId: string;
+  groupKey: string;
+  localBalance: string;
+  remoteBalance: string;
+  capacity: string;
+};
+
 /** Timeout for sendPayment RPC before the stream-level guard kicks in. */
 const SEND_PAYMENT_TIMEOUT_SECONDS = 60;
 const FEE_LIMIT_MAX = 100;
@@ -381,17 +391,7 @@ export class TapdNodeService {
   async getAssetChannelBalances(opts: {
     id: string;
     peerPubkey?: string;
-  }): Promise<
-    {
-      channelPoint: string;
-      partnerPublicKey: string;
-      assetId: string;
-      groupKey: string;
-      localBalance: string;
-      remoteBalance: string;
-      capacity: string;
-    }[]
-  > {
+  }): Promise<AssetChannelInfo[]> {
     const account = this.getAccount(opts.id);
     const provider = this.providerRegistry.getProvider(account.type);
     const capabilities = provider.getCapabilities();
@@ -422,15 +422,7 @@ export class TapdNodeService {
         ) => {
           if (err) return reject(err);
 
-          const results: {
-            channelPoint: string;
-            partnerPublicKey: string;
-            assetId: string;
-            groupKey: string;
-            localBalance: string;
-            remoteBalance: string;
-            capacity: string;
-          }[] = [];
+          const results: AssetChannelInfo[] = [];
 
           for (const ch of res.channels || []) {
             if (!ch.custom_channel_data?.length) continue;
@@ -457,6 +449,74 @@ export class TapdNodeService {
                 channelPoint: ch.channel_point,
                 err,
               });
+            }
+          }
+
+          resolve(results);
+        }
+      );
+    });
+  }
+
+  async getPendingAssetChannels(opts: {
+    id: string;
+  }): Promise<AssetChannelInfo[]> {
+    const account = this.getAccount(opts.id);
+    const provider = this.providerRegistry.getProvider(account.type);
+    const capabilities = provider.getCapabilities();
+
+    if (!capabilities.has(Capability.TAPROOT_ASSETS)) {
+      return [];
+    }
+
+    const connection = account.connection;
+    const lnd = connection.lnd ?? connection;
+
+    return new Promise((resolve, reject) => {
+      lnd.default.pendingChannels(
+        {},
+        (
+          err: Error | null,
+          res: {
+            pending_open_channels: {
+              channel: {
+                channel_point: string;
+                remote_node_pub: string;
+                custom_channel_data: Buffer;
+              };
+            }[];
+          }
+        ) => {
+          if (err) return reject(err);
+
+          const results: AssetChannelInfo[] = [];
+
+          for (const entry of res.pending_open_channels || []) {
+            const ch = entry.channel;
+            if (!ch?.custom_channel_data?.length) continue;
+
+            try {
+              const data = JSON.parse(ch.custom_channel_data.toString('utf8'));
+              const fundingAsset = data.funding_assets?.[0];
+              const assetId = fundingAsset?.asset_genesis?.asset_id || '';
+              if (!assetId) continue;
+
+              const groupKey = data.group_key;
+
+              results.push({
+                channelPoint: ch.channel_point,
+                partnerPublicKey: ch.remote_node_pub,
+                assetId,
+                groupKey,
+                localBalance: String(data.local_balance ?? 0),
+                remoteBalance: String(data.remote_balance ?? 0),
+                capacity: String(data.capacity ?? 0),
+              });
+            } catch (parseErr) {
+              this.logger.warn(
+                'Failed to parse custom_channel_data for pending channel',
+                { channelPoint: ch.channel_point, err: parseErr }
+              );
             }
           }
 


### PR DESCRIPTION
## Summary
- **Pending channel awareness in TradeSheet**: shows opening channels (BTC + asset), prefills sats amount from pending/open asset capacity, suppresses input when all channels are pending, checks pending BTC capacity before skipping outbound setup
- **Channel status column in TradingOffers**: each offer row shows BTC/Asset labels (green = open, dim = missing, blue clock = pending)
- **Server**: new `getPendingAssetChannels` method on tapd-node service; `getPendingChannels` resolver enriched with asset data from `custom_channel_data`

## Test plan
- [ ] Open trade sheet for an offer where you have a pending asset channel — verify it shows as a blue "opening" card and prefills sats
- [ ] Open trade sheet where both channels are pending — verify input is suppressed with blue info box
- [ ] Open trade sheet where channels are open but balance is insufficient — verify input stays visible (can adjust amount)
- [ ] Check offer list Channels column shows correct BTC/Asset status for each offer node
- [ ] Verify no duplicate Magma orders when pending channels already cover the needed capacity
- [ ] `npm run lint:check` passes
- [ ] `npm run test` passes (107 tests)
- [ ] `npm run build` passes