### PR TITLE
fix: handle decimal amounts in trade input

### DIFF
--- a/src/client/src/views/assets/TradeSheet.tsx
+++ b/src/client/src/views/assets/TradeSheet.tsx
@@ -214,7 +214,7 @@ export const TradeSheet: FC<TradeSheetProps> = ({
     0
   );
 
-  const isValid = amount && BigInt(amount) > 0n;
+  const isValid = amount && Number(amount) > 0;
 
   // Determine input mode from raw capacity to avoid circular dependency.
   // When buying with existing asset inbound but no BTC outbound, the user


### PR DESCRIPTION
## Summary
- Fix `Uncaught SyntaxError: invalid BigInt syntax` when entering a decimal trade amount (e.g. "1.5" for an asset with precision > 0)
- `BigInt()` cannot parse decimal strings — replaced the validity check with `Number(amount) > 0`
- The downstream atomic conversion (`displayToAtomic`) already handles decimals correctly

## Test plan
- [ ] Enter a decimal amount (e.g. "1.5") for an asset with precision > 0 — no error
- [ ] Enter a whole number amount — still works as before
- [ ] Enter "0" or empty — button stays disabled