### PR TITLE
fix: route trade payments through virtual SCID via payViaRoutes

### DIFF
--- a/schema.gql
+++ b/schema.gql
@@ -1178,6 +1178,7 @@ type TeamMutations {
 
 input TradeQuoteInput {
   assetAmount: String!
+  expiry: Float
   peerPubkey: String!
   tapdAssetId: String!
   tapdGroupKey: String

--- a/src/client/src/graphql/types.ts
+++ b/src/client/src/graphql/types.ts
@@ -1618,6 +1618,7 @@ export type TeamMutationsEdit_NodeArgs = {
 
 export type TradeQuoteInput = {
   assetAmount: Scalars['String']['input'];
+  expiry?: InputMaybe<Scalars['Float']['input']>;
   peerPubkey: Scalars['String']['input'];
   tapdAssetId: Scalars['String']['input'];
   tapdGroupKey?: InputMaybe<Scalars['String']['input']>;

--- a/src/server/modules/api/trade/trade.resolver.spec.ts
+++ b/src/server/modules/api/trade/trade.resolver.spec.ts
@@ -11,8 +11,37 @@ jest.mock('../../security/security.types', () => ({}));
 
 import { TradeResolver } from './trade.resolver';
 
-// Access private method for direct unit testing of return-hint construction.
-type BuildBtcReturnHint = (id: string, peerPubkey: string) => Promise<unknown>;
+type BtcChannel = {
+  id: string;
+  capacity: number;
+  local_balance: number;
+  remote_balance: number;
+};
+
+type RouteHop = {
+  public_key: string;
+  channel?: string;
+  cltv_delta?: number;
+};
+
+// Combined private-method accessor to avoid repeating the cast per suite.
+interface PrivateMethods {
+  buildBtcReturnHint(
+    id: string,
+    peerPubkey: string,
+    btcChannels: BtcChannel[]
+  ): Promise<unknown>;
+  getBtcChannelsWithPeer(id: string, peerPubkey: string): Promise<BtcChannel[]>;
+  findVirtualScidHint(
+    routes: RouteHop[][],
+    peerPubkey: string
+  ): { channel: string; cltv_delta?: number } | undefined;
+  deriveSatsFromRate(
+    assetAmount: string,
+    rate: { coefficient: string; scale: number },
+    minTransportableMsat: string
+  ): number;
+}
 
 describe('TradeResolver', () => {
   const userId = 'test-user-id';
@@ -28,6 +57,7 @@ describe('TradeResolver', () => {
   const mockLogger = { error: jest.fn(), warn: jest.fn(), info: jest.fn() };
 
   let resolver: TradeResolver;
+  let priv: PrivateMethods;
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -41,11 +71,12 @@ describe('TradeResolver', () => {
       mockNodeService as never,
       mockLogger as never
     );
+    priv = resolver as unknown as PrivateMethods;
   });
 
   // ── Regression guard against upstream channelTypes mapping ──
-  // buildBtcReturnHint filters BTC channels by truthy `type`, which relies on
-  // the `lightning` package leaving SIMPLE_TAPROOT_OVERLAY unmapped (undefined)
+  // getBtcChannelsWithPeer filters BTC channels by truthy `type`, which relies
+  // on the `lightning` package leaving SIMPLE_TAPROOT_OVERLAY unmapped (undefined)
   // while mapping real BTC commitment types (ANCHORS, SIMPLE_TAPROOT, …) to
   // non-empty strings. If upstream ever adds an entry for SIMPLE_TAPROOT_OVERLAY,
   // the filter will start treating TA channels as BTC and the self-pay loop
@@ -71,51 +102,26 @@ describe('TradeResolver', () => {
   // ── buildBtcReturnHint ──
 
   describe('buildBtcReturnHint', () => {
-    const buildHint = () => {
-      const privateResolver = resolver as unknown as {
-        buildBtcReturnHint: BuildBtcReturnHint;
-      };
-      return privateResolver.buildBtcReturnHint.call(
-        resolver,
-        userId,
-        peerPubkey
-      );
-    };
-
-    it('skips TA channels (type undefined) when selecting the BTC return channel', async () => {
-      mockNodeService.getChannels.mockResolvedValue({
-        channels: [
-          // Taproot Asset channel has the largest remote_balance but must be skipped
-          {
-            id: 'ta-channel',
-            type: undefined,
-            remote_balance: 10_000_000,
-          },
-          { id: 'btc-channel', type: 'anchor', remote_balance: 500_000 },
-        ],
-      });
-
-      const hint = await buildHint();
-
-      expect(Array.isArray(hint)).toBe(true);
-      expect((hint as Array<{ channel?: string }>)[1].channel).toBe(
-        'btc-channel'
-      );
+    const btcChannel = (
+      id: string,
+      remote: number
+    ): BtcChannel & { type: string } => ({
+      id,
+      type: 'anchor',
+      capacity: 2_000_000,
+      local_balance: 1_000_000,
+      remote_balance: remote,
     });
 
     it('picks the BTC channel with the largest remote_balance', async () => {
-      // Input order scrambled so `.find()`-style selection on the original array
-      // would pick the wrong channel — forces reliance on the sort.
-      mockNodeService.getChannels.mockResolvedValue({
-        channels: [
-          { id: 'btc-medium', type: 'anchor', remote_balance: 200_000 },
-          { id: 'btc-small', type: 'anchor', remote_balance: 50_000 },
-          { id: 'btc-largest', type: 'anchor', remote_balance: 900_000 },
-          { id: 'btc-large', type: 'anchor', remote_balance: 500_000 },
-        ],
-      });
+      const channels = [
+        btcChannel('btc-medium', 200_000),
+        btcChannel('btc-small', 50_000),
+        btcChannel('btc-largest', 900_000),
+        btcChannel('btc-large', 500_000),
+      ];
 
-      const hint = await buildHint();
+      const hint = await priv.buildBtcReturnHint(userId, peerPubkey, channels);
 
       expect((hint as Array<{ channel?: string }>)[1].channel).toBe(
         'btc-largest'
@@ -127,20 +133,15 @@ describe('TradeResolver', () => {
     });
 
     it("uses the peer's gossiped policy when available", async () => {
-      mockNodeService.getChannels.mockResolvedValue({
-        channels: [{ id: 'btc-1', type: 'anchor', remote_balance: 500_000 }],
-      });
       mockNodeService.getChannel.mockResolvedValue({
         id: 'btc-1',
         policies: [
-          // Our side of the channel — must be ignored
           {
             public_key: myPubkey,
             base_fee_mtokens: '0',
             fee_rate: 1,
             cltv_delta: 144,
           },
-          // Peer side — drives the hint
           {
             public_key: peerPubkey,
             base_fee_mtokens: '500',
@@ -150,7 +151,9 @@ describe('TradeResolver', () => {
         ],
       });
 
-      const hint = await buildHint();
+      const hint = await priv.buildBtcReturnHint(userId, peerPubkey, [
+        btcChannel('btc-1', 500_000),
+      ]);
 
       expect(hint).toEqual([
         { public_key: peerPubkey },
@@ -165,12 +168,8 @@ describe('TradeResolver', () => {
     });
 
     it('falls back to conservative defaults when peer policy is missing from gossip', async () => {
-      mockNodeService.getChannels.mockResolvedValue({
-        channels: [{ id: 'btc-1', type: 'anchor', remote_balance: 500_000 }],
-      });
       mockNodeService.getChannel.mockResolvedValue({
         id: 'btc-1',
-        // Only our policy gossiped — peer hasn't announced one yet
         policies: [
           {
             public_key: myPubkey,
@@ -181,7 +180,9 @@ describe('TradeResolver', () => {
         ],
       });
 
-      const hint = await buildHint();
+      const hint = await priv.buildBtcReturnHint(userId, peerPubkey, [
+        btcChannel('btc-1', 500_000),
+      ]);
 
       expect(hint).toEqual([
         { public_key: peerPubkey },
@@ -195,36 +196,168 @@ describe('TradeResolver', () => {
       ]);
     });
 
-    it('returns undefined when the peer has only TA channels', async () => {
-      mockNodeService.getChannels.mockResolvedValue({
-        channels: [
-          { id: 'ta-1', type: undefined, remote_balance: 10_000_000 },
-          { id: 'ta-2', type: undefined, remote_balance: 20_000_000 },
-        ],
-      });
-
-      await expect(buildHint()).resolves.toBeUndefined();
+    it('returns undefined when given an empty channels array', async () => {
+      await expect(
+        priv.buildBtcReturnHint(userId, peerPubkey, [])
+      ).resolves.toBeUndefined();
       expect(mockLogger.warn).toHaveBeenCalledWith(
         'No BTC channel with peer; omitting return hint',
         expect.any(Object)
       );
     });
 
-    it('returns undefined when getChannels fails', async () => {
-      mockNodeService.getChannels.mockRejectedValue(new Error('rpc down'));
-
-      await expect(buildHint()).resolves.toBeUndefined();
-      // Must not have attempted identity lookup after channel fetch failure.
-      expect(mockNodeService.getIdentity).not.toHaveBeenCalled();
-    });
-
     it('returns undefined when getIdentity fails', async () => {
-      mockNodeService.getChannels.mockResolvedValue({
-        channels: [{ id: 'btc-1', type: 'anchor', remote_balance: 100_000 }],
-      });
       mockNodeService.getIdentity.mockRejectedValue(new Error('no identity'));
 
-      await expect(buildHint()).resolves.toBeUndefined();
+      await expect(
+        priv.buildBtcReturnHint(userId, peerPubkey, [
+          btcChannel('btc-1', 100_000),
+        ])
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  // ── getBtcChannelsWithPeer ──
+
+  describe('getBtcChannelsWithPeer', () => {
+    it('filters out TA channels (type undefined)', async () => {
+      mockNodeService.getChannels.mockResolvedValue({
+        channels: [
+          {
+            id: 'ta-1',
+            type: undefined,
+            capacity: 1_000_000,
+            local_balance: 500_000,
+            remote_balance: 500_000,
+          },
+          {
+            id: 'btc-1',
+            type: 'anchor',
+            capacity: 2_000_000,
+            local_balance: 1_000_000,
+            remote_balance: 1_000_000,
+          },
+        ],
+      });
+
+      const result = await priv.getBtcChannelsWithPeer(userId, peerPubkey);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe('btc-1');
+    });
+
+    it('returns empty array and logs warning on getChannels error', async () => {
+      mockNodeService.getChannels.mockRejectedValue(new Error('rpc down'));
+
+      const result = await priv.getBtcChannelsWithPeer(userId, peerPubkey);
+
+      expect(result).toEqual([]);
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        'Failed to fetch channels with peer',
+        expect.objectContaining({ peerPubkey })
+      );
+    });
+
+    it('returns empty array when peer has no channels', async () => {
+      mockNodeService.getChannels.mockResolvedValue({ channels: [] });
+
+      const result = await priv.getBtcChannelsWithPeer(userId, peerPubkey);
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  // ── findVirtualScidHint ──
+
+  describe('findVirtualScidHint', () => {
+    it('finds hint on the peer entry itself', () => {
+      const routes = [
+        [{ public_key: peerPubkey, channel: '123x1x0', cltv_delta: 144 }],
+      ];
+
+      expect(priv.findVirtualScidHint(routes, peerPubkey)).toEqual({
+        channel: '123x1x0',
+        cltv_delta: 144,
+      });
+    });
+
+    it('finds hint on the next entry (destination) when peer entry has no channel', () => {
+      const destPubkey = 'ee'.repeat(33);
+      const routes = [
+        [
+          { public_key: peerPubkey },
+          { public_key: destPubkey, channel: '456x2x1', cltv_delta: 80 },
+        ],
+      ];
+
+      expect(priv.findVirtualScidHint(routes, peerPubkey)).toEqual({
+        channel: '456x2x1',
+        cltv_delta: 80,
+      });
+    });
+
+    it('returns undefined when peer pubkey is not in any route', () => {
+      const otherPubkey = 'ff'.repeat(33);
+      const routes = [
+        [{ public_key: otherPubkey, channel: '789x3x0', cltv_delta: 40 }],
+      ];
+
+      expect(priv.findVirtualScidHint(routes, peerPubkey)).toBeUndefined();
+    });
+
+    it('returns undefined for empty routes', () => {
+      expect(priv.findVirtualScidHint([], peerPubkey)).toBeUndefined();
+    });
+
+    it('searches across multiple routes and returns the first match', () => {
+      const otherPubkey = 'ff'.repeat(33);
+      const routes = [
+        [{ public_key: otherPubkey, channel: '111x1x0' }],
+        [{ public_key: peerPubkey, channel: '222x2x0', cltv_delta: 100 }],
+      ];
+
+      expect(priv.findVirtualScidHint(routes, peerPubkey)).toEqual({
+        channel: '222x2x0',
+        cltv_delta: 100,
+      });
+    });
+  });
+
+  // ── deriveSatsFromRate ──
+
+  describe('deriveSatsFromRate', () => {
+    it('computes sats from rate and asset amount', () => {
+      // rate = 50000 * 10^(-2) = 500 assets per BTC
+      // 100 assets at 500/BTC = 0.2 BTC = 20_000_000 sats
+      const sats = priv.deriveSatsFromRate(
+        '100',
+        { coefficient: '50000', scale: 2 },
+        '0'
+      );
+
+      expect(sats).toBe(20_000_000);
+    });
+
+    it('ceils to the next sat', () => {
+      // rate = 3 * 10^0 = 3 assets per BTC
+      // 1 asset at 3/BTC = 0.333... BTC = 33_333_334 sats (ceil)
+      const sats = priv.deriveSatsFromRate(
+        '1',
+        { coefficient: '3', scale: 0 },
+        '0'
+      );
+
+      expect(sats).toBe(33_333_334);
+    });
+
+    it('respects minTransportableMsat floor', () => {
+      const sats = priv.deriveSatsFromRate(
+        '1',
+        { coefficient: '100000000', scale: 0 },
+        '10000000'
+      );
+
+      expect(sats).toBeGreaterThanOrEqual(10_000);
     });
   });
 });

--- a/src/server/modules/api/trade/trade.resolver.ts
+++ b/src/server/modules/api/trade/trade.resolver.ts
@@ -201,8 +201,6 @@ export class TradeResolver {
       );
     }
 
-    // Decode the invoice to extract the payment hash, amount, cltv_delta,
-    // route hints (containing the virtual SCID), and payment address.
     const [decoded, decodeError] = await toWithError(
       this.nodeService.decodePaymentRequest(id, paymentRequest)
     );
@@ -220,9 +218,6 @@ export class TradeResolver {
       );
     }
 
-    // Extract the virtual SCID from the invoice's route hints. The RFQ buy
-    // quote embeds a route hint with the peer's pubkey and the virtual SCID
-    // that tapd's HTLC interceptor listens on.
     this.logger.debug('Decoded invoice route hints', {
       routes: JSON.stringify(decoded.routes),
       peerPubkey: input.peerPubkey,
@@ -250,45 +245,46 @@ export class TradeResolver {
       cltvDelta: routeHint.cltv_delta,
     });
 
-    await this.assertBtcLiquidity(
-      id,
-      input.peerPubkey,
-      decoded.tokens,
-      'local'
-    );
+    const btcChannels = await this.getBtcChannelsWithPeer(id, input.peerPubkey);
 
-    // Gather the data needed to construct the explicit 2-hop route:
-    // current block height, our identity pubkey, BTC channel with peer, and
-    // the peer's fee policy on that channel.
-    const [heightResult, heightError] = await toWithError(
-      this.nodeService.getHeight(id)
-    );
+    if (btcChannels.length === 0) {
+      throw new GraphQLError(
+        'No active BTC channel with trade partner — cannot execute trade'
+      );
+    }
+
+    const btcChannel = [...btcChannels].sort(
+      (a, b) => b.local_balance - a.local_balance
+    )[0];
+
+    if (btcChannel.local_balance < decoded.tokens) {
+      throw new GraphQLError(
+        `Insufficient outbound BTC liquidity with trade partner: need ${decoded.tokens} sats, have ${btcChannel.local_balance} sats`
+      );
+    }
+
+    const [
+      [heightResult, heightError],
+      [identity, identityError],
+      [channelInfo],
+    ] = await Promise.all([
+      toWithError(this.nodeService.getHeight(id)),
+      toWithError(this.nodeService.getIdentity(id)),
+      toWithError(this.nodeService.getChannel(id, btcChannel.id)),
+    ]);
 
     if (heightError || !heightResult?.current_block_height) {
       throw new GraphQLError('Failed to get current block height');
     }
 
-    const [identity, identityError] = await toWithError(
-      this.nodeService.getIdentity(id)
-    );
-
     if (identityError || !identity?.public_key) {
       throw new GraphQLError('Failed to get node identity');
     }
 
-    const btcChannel = await this.findBtcChannelWithPeer(id, input.peerPubkey);
-
-    const [channelInfo] = await toWithError(
-      this.nodeService.getChannel(id, btcChannel.id)
-    );
     const peerPolicy = channelInfo?.policies?.find(
       (p: { public_key: string }) => p.public_key === input.peerPubkey
     );
 
-    // Build the explicit 2-hop route: sender → peer (BTC channel) → sender
-    // (virtual SCID). This forces LND to route through the virtual edge that
-    // tapd's HTLC interceptor listens on, instead of letting pathfinding
-    // skip it due to fee heuristics.
     const currentHeight: number = heightResult.current_block_height;
     const invoiceCltvDelta = decoded.cltv_delta ?? 40;
     const hintCltvDelta = routeHint.cltv_delta ?? 144;
@@ -302,7 +298,6 @@ export class TradeResolver {
     const hopCltvDelta = Math.max(hintCltvDelta, btcChannelCltvDelta);
     const hop1Timeout = hop2Timeout + hopCltvDelta;
 
-    // Hop 1 fee: base_fee + (forward_amount * fee_rate / 1_000_000)
     const forwardMtokens = BigInt(decoded.mtokens);
     const baseFee = BigInt(peerPolicy?.base_fee_mtokens ?? '1000');
     const feeRate = BigInt(peerPolicy?.fee_rate ?? 2500);
@@ -596,7 +591,14 @@ export class TradeResolver {
   private async getBtcChannelsWithPeer(
     id: string,
     peerPubkey: string
-  ): Promise<Array<{ local_balance: number; remote_balance: number }>> {
+  ): Promise<
+    Array<{
+      id: string;
+      capacity: number;
+      local_balance: number;
+      remote_balance: number;
+    }>
+  > {
     const [channelsResult, channelsError] = await toWithError(
       this.nodeService.getChannels(id, {
         partner_public_key: peerPubkey,
@@ -610,7 +612,12 @@ export class TradeResolver {
 
     return channelsResult.channels.filter(
       (ch: { type?: string }) => !!ch.type
-    ) as Array<{ local_balance: number; remote_balance: number }>;
+    ) as Array<{
+      id: string;
+      capacity: number;
+      local_balance: number;
+      remote_balance: number;
+    }>;
   }
 
   /**
@@ -689,7 +696,6 @@ export class TradeResolver {
       const peerIdx = route.findIndex(hop => hop.public_key === peerPubkey);
       if (peerIdx === -1) continue;
 
-      // Check the peer's own entry first
       if (route[peerIdx].channel) {
         return {
           channel: route[peerIdx].channel as string,
@@ -704,49 +710,6 @@ export class TradeResolver {
       }
     }
     return undefined;
-  }
-
-  /**
-   * Finds the best BTC channel with the given peer (highest local balance),
-   * including channel ID and capacity needed for route construction.
-   */
-  private async findBtcChannelWithPeer(
-    id: string,
-    peerPubkey: string
-  ): Promise<{ id: string; capacity: number; local_balance: number }> {
-    const [channelsResult, channelsError] = await toWithError(
-      this.nodeService.getChannels(id, {
-        partner_public_key: peerPubkey,
-        is_active: true,
-      })
-    );
-
-    if (channelsError || !channelsResult?.channels?.length) {
-      throw new GraphQLError(
-        'No active channels with trade partner — cannot execute trade'
-      );
-    }
-
-    // Filter to BTC-only channels (TA channels have undefined `type`) and
-    // pick the one with the most local balance for the outgoing BTC leg.
-    const btcChannels = channelsResult.channels
-      .filter((ch: { type?: string }) => !!ch.type)
-      .sort(
-        (a: { local_balance: number }, b: { local_balance: number }) =>
-          b.local_balance - a.local_balance
-      );
-
-    const best = btcChannels[0] as
-      | { id: string; capacity: number; local_balance: number }
-      | undefined;
-
-    if (!best) {
-      throw new GraphQLError(
-        'No active BTC channel with trade partner — cannot execute trade'
-      );
-    }
-
-    return best;
   }
 
   /**

--- a/src/server/modules/api/trade/trade.resolver.ts
+++ b/src/server/modules/api/trade/trade.resolver.ts
@@ -77,6 +77,7 @@ export class TradeResolver {
         groupKey: input.tapdGroupKey || undefined,
         assetAmount: input.assetAmount,
         peerPubkey: input.peerPubkey,
+        expiry: 30,
       })
     );
 
@@ -87,6 +88,22 @@ export class TradeResolver {
 
     const quote = invoice.acceptedBuyQuote;
     const rate = quote?.askAssetRate;
+
+    // The peer may accept fewer assets than requested. Verify and fail early
+    // so the user doesn't unknowingly pay for fewer assets than intended.
+    const acceptedAmount = quote?.assetMaxAmount;
+    if (
+      acceptedAmount &&
+      String(acceptedAmount) !== String(input.assetAmount)
+    ) {
+      this.logger.warn('Peer accepted fewer assets than requested', {
+        requested: input.assetAmount,
+        accepted: acceptedAmount,
+      });
+      throw new GraphQLError(
+        `Peer can only convert ${acceptedAmount} assets (requested ${input.assetAmount})`
+      );
+    }
 
     const paymentRequest = invoice.invoiceResult?.paymentRequest || '';
     const [decoded, decodeError] = await toWithError(
@@ -105,7 +122,8 @@ export class TradeResolver {
     this.logger.info('Buy quote received', {
       assetAmount: input.assetAmount,
       sats,
-      rfqId: Buffer.from(quote.id).toString('hex'),
+      rfqId: quote?.id ? Buffer.from(quote.id).toString('hex') : undefined,
+      expiry: quote?.expiry,
       quote,
     });
 
@@ -183,9 +201,8 @@ export class TradeResolver {
       );
     }
 
-    // Decode the invoice so we know the exact sats leg before paying it,
-    // then verify we actually have enough local BTC liquidity with the peer.
-    // Fails fast with a friendly error instead of letting the payment stall.
+    // Decode the invoice to extract the payment hash, amount, cltv_delta,
+    // route hints (containing the virtual SCID), and payment address.
     const [decoded, decodeError] = await toWithError(
       this.nodeService.decodePaymentRequest(id, paymentRequest)
     );
@@ -197,45 +214,177 @@ export class TradeResolver {
       throw new GraphQLError('Failed to decode asset invoice');
     }
 
-    const btcChannels = await this.getBtcChannelsWithPeer(id, input.peerPubkey);
-
-    if (btcChannels.length === 0) {
+    if (!decoded.payment) {
       throw new GraphQLError(
-        'No active BTC channel with trade partner — cannot execute trade'
+        'Invoice missing payment address — cannot construct route'
       );
     }
 
-    const sortedByLocal = [...btcChannels].sort(
-      (a, b) => b.local_balance - a.local_balance
-    );
-    const bestChannel = sortedByLocal[0];
-
-    if (bestChannel.local_balance < decoded.tokens) {
-      throw new GraphQLError(
-        `Insufficient outbound BTC liquidity with trade partner: need ${decoded.tokens} sats, have ${bestChannel.local_balance} sats`
-      );
-    }
-
-    this.logger.info('Executing buy trade', {
-      assetAmount: input.assetAmount,
-      invoicePrefix: paymentRequest,
-      outgoingChannel: bestChannel.id,
+    // Extract the virtual SCID from the invoice's route hints. The RFQ buy
+    // quote embeds a route hint with the peer's pubkey and the virtual SCID
+    // that tapd's HTLC interceptor listens on.
+    this.logger.debug('Decoded invoice route hints', {
+      routes: JSON.stringify(decoded.routes),
+      peerPubkey: input.peerPubkey,
+      cltvDelta: decoded.cltv_delta,
+      paymentHash: decoded.id,
     });
 
-    const [payResult, payError] = await toWithError(
-      this.nodeService.pay(id, {
-        request: paymentRequest,
-        is_allow_self_payment: true,
-        outgoing_channel: bestChannel.id,
-      })
+    const routeHint = this.findVirtualScidHint(
+      decoded.routes,
+      input.peerPubkey
     );
 
-    if (payError || !payResult?.is_confirmed) {
-      this.logger.error('Failed to pay asset invoice', {
-        error: payError,
-        paymentRequest,
-        payResult,
+    if (!routeHint) {
+      this.logger.error('No virtual SCID route hint found in invoice', {
+        routes: JSON.stringify(decoded.routes),
+        peerPubkey: input.peerPubkey,
       });
+      throw new GraphQLError(
+        'Invoice has no route hint for the trade peer — was it created via addAssetInvoice?'
+      );
+    }
+
+    this.logger.debug('Found virtual SCID route hint', {
+      virtualScid: routeHint.channel,
+      cltvDelta: routeHint.cltv_delta,
+    });
+
+    await this.assertBtcLiquidity(
+      id,
+      input.peerPubkey,
+      decoded.tokens,
+      'local'
+    );
+
+    // Gather the data needed to construct the explicit 2-hop route:
+    // current block height, our identity pubkey, BTC channel with peer, and
+    // the peer's fee policy on that channel.
+    const [heightResult, heightError] = await toWithError(
+      this.nodeService.getHeight(id)
+    );
+
+    if (heightError || !heightResult?.current_block_height) {
+      throw new GraphQLError('Failed to get current block height');
+    }
+
+    const [identity, identityError] = await toWithError(
+      this.nodeService.getIdentity(id)
+    );
+
+    if (identityError || !identity?.public_key) {
+      throw new GraphQLError('Failed to get node identity');
+    }
+
+    const btcChannel = await this.findBtcChannelWithPeer(id, input.peerPubkey);
+
+    const [channelInfo] = await toWithError(
+      this.nodeService.getChannel(id, btcChannel.id)
+    );
+    const peerPolicy = channelInfo?.policies?.find(
+      (p: { public_key: string }) => p.public_key === input.peerPubkey
+    );
+
+    // Build the explicit 2-hop route: sender → peer (BTC channel) → sender
+    // (virtual SCID). This forces LND to route through the virtual edge that
+    // tapd's HTLC interceptor listens on, instead of letting pathfinding
+    // skip it due to fee heuristics.
+    const currentHeight: number = heightResult.current_block_height;
+    const invoiceCltvDelta = decoded.cltv_delta ?? 40;
+    const hintCltvDelta = routeHint.cltv_delta ?? 144;
+    const btcChannelCltvDelta: number = peerPolicy?.cltv_delta ?? 40;
+
+    // +3 block buffer on final CLTV to tolerate a block arriving between
+    // getHeight and HTLC settlement. Use the larger of the virtual SCID's
+    // cltv_delta and the BTC channel's cltv_delta for the hop delta — the
+    // peer may enforce its BTC channel policy on forwards.
+    const hop2Timeout = currentHeight + invoiceCltvDelta + 3;
+    const hopCltvDelta = Math.max(hintCltvDelta, btcChannelCltvDelta);
+    const hop1Timeout = hop2Timeout + hopCltvDelta;
+
+    // Hop 1 fee: base_fee + (forward_amount * fee_rate / 1_000_000)
+    const forwardMtokens = BigInt(decoded.mtokens);
+    const baseFee = BigInt(peerPolicy?.base_fee_mtokens ?? '1000');
+    const feeRate = BigInt(peerPolicy?.fee_rate ?? 2500);
+    const hop1FeeMtokens =
+      baseFee + (forwardMtokens * feeRate) / BigInt(1_000_000);
+    const hop1Fee = Number((hop1FeeMtokens + BigInt(999)) / BigInt(1000));
+
+    const totalMtokens = forwardMtokens + hop1FeeMtokens;
+
+    const route = {
+      fee: hop1Fee,
+      fee_mtokens: String(hop1FeeMtokens),
+      hops: [
+        {
+          channel: btcChannel.id,
+          channel_capacity: btcChannel.capacity,
+          fee: hop1Fee,
+          fee_mtokens: String(hop1FeeMtokens),
+          forward: decoded.tokens,
+          forward_mtokens: decoded.mtokens,
+          public_key: input.peerPubkey,
+          timeout: hop2Timeout,
+        },
+        {
+          channel: routeHint.channel,
+          channel_capacity: btcChannel.capacity,
+          fee: 0,
+          fee_mtokens: '0',
+          forward: decoded.tokens,
+          forward_mtokens: decoded.mtokens,
+          public_key: identity.public_key,
+          timeout: hop2Timeout,
+        },
+      ],
+      mtokens: String(totalMtokens),
+      payment: decoded.payment,
+      timeout: hop1Timeout,
+      tokens: Number((totalMtokens + BigInt(999)) / BigInt(1000)),
+      total_mtokens: decoded.mtokens,
+    };
+
+    this.logger.info('Executing buy trade via explicit route', {
+      assetAmount: input.assetAmount,
+      invoicePrefix: paymentRequest.slice(0, 20),
+      virtualScid: routeHint.channel,
+      btcChannelId: btcChannel.id,
+      currentHeight,
+      hintCltvDelta,
+      btcChannelCltvDelta,
+      hopCltvDelta,
+      route,
+    });
+
+    let payResult:
+      | {
+          is_confirmed: boolean;
+          secret: string;
+          safe_tokens?: number;
+          fee?: number;
+        }
+      | undefined;
+
+    try {
+      payResult = await this.nodeService.payViaRoutes(id, {
+        id: decoded.id,
+        routes: [route],
+      });
+    } catch (err: unknown) {
+      // payViaRoutes throws [code, message, {failures}] on failure.
+      // Log the full failure chain for debugging CLTV/routing issues.
+      const rawErr = err as unknown[];
+      const failures = Array.isArray(rawErr) ? rawErr[2] : undefined;
+      this.logger.error('Failed to pay asset invoice via route', {
+        error: Array.isArray(rawErr) ? rawErr[1] : String(err),
+        failures: JSON.stringify(failures),
+        paymentRequest,
+      });
+      throw new GraphQLError('Failed to pay asset invoice with sats');
+    }
+
+    if (!payResult?.is_confirmed) {
+      this.logger.error('Payment via route not confirmed', { payResult });
       throw new GraphQLError('Failed to pay asset invoice with sats');
     }
 
@@ -447,9 +596,7 @@ export class TradeResolver {
   private async getBtcChannelsWithPeer(
     id: string,
     peerPubkey: string
-  ): Promise<
-    Array<{ id: string; local_balance: number; remote_balance: number }>
-  > {
+  ): Promise<Array<{ local_balance: number; remote_balance: number }>> {
     const [channelsResult, channelsError] = await toWithError(
       this.nodeService.getChannels(id, {
         partner_public_key: peerPubkey,
@@ -463,7 +610,7 @@ export class TradeResolver {
 
     return channelsResult.channels.filter(
       (ch: { type?: string }) => !!ch.type
-    ) as Array<{ id: string; local_balance: number; remote_balance: number }>;
+    ) as Array<{ local_balance: number; remote_balance: number }>;
   }
 
   /**
@@ -524,6 +671,82 @@ export class TradeResolver {
       minMsat > BigInt(0) ? Number((minMsat + BigInt(999)) / BigInt(1000)) : 0;
 
     return Math.max(sats, minSats);
+  }
+
+  /**
+   * Finds the virtual SCID route hint embedded by tapd's addAssetInvoice.
+   * BOLT11 route hints use RouteNode[] where each entry has a public_key. The
+   * channel/cltv_delta may live on the peer's own entry or on the next entry
+   * (destination), depending on the encoding convention. We check both.
+   */
+  private findVirtualScidHint(
+    routes: Array<
+      Array<{ public_key: string; channel?: string; cltv_delta?: number }>
+    >,
+    peerPubkey: string
+  ): { channel: string; cltv_delta?: number } | undefined {
+    for (const route of routes) {
+      const peerIdx = route.findIndex(hop => hop.public_key === peerPubkey);
+      if (peerIdx === -1) continue;
+
+      // Check the peer's own entry first
+      if (route[peerIdx].channel) {
+        return {
+          channel: route[peerIdx].channel as string,
+          cltv_delta: route[peerIdx].cltv_delta,
+        };
+      }
+
+      // lightning package convention: channel on the next entry (destination)
+      const nextHop = route[peerIdx + 1];
+      if (nextHop?.channel) {
+        return { channel: nextHop.channel, cltv_delta: nextHop.cltv_delta };
+      }
+    }
+    return undefined;
+  }
+
+  /**
+   * Finds the best BTC channel with the given peer (highest local balance),
+   * including channel ID and capacity needed for route construction.
+   */
+  private async findBtcChannelWithPeer(
+    id: string,
+    peerPubkey: string
+  ): Promise<{ id: string; capacity: number; local_balance: number }> {
+    const [channelsResult, channelsError] = await toWithError(
+      this.nodeService.getChannels(id, {
+        partner_public_key: peerPubkey,
+        is_active: true,
+      })
+    );
+
+    if (channelsError || !channelsResult?.channels?.length) {
+      throw new GraphQLError(
+        'No active channels with trade partner — cannot execute trade'
+      );
+    }
+
+    // Filter to BTC-only channels (TA channels have undefined `type`) and
+    // pick the one with the most local balance for the outgoing BTC leg.
+    const btcChannels = channelsResult.channels
+      .filter((ch: { type?: string }) => !!ch.type)
+      .sort(
+        (a: { local_balance: number }, b: { local_balance: number }) =>
+          b.local_balance - a.local_balance
+      );
+
+    const best = btcChannels[0] as
+      | { id: string; capacity: number; local_balance: number }
+      | undefined;
+
+    if (!best) {
+      throw new GraphQLError(
+        'No active BTC channel with trade partner — cannot execute trade'
+      );
+    }
+
+    return best;
   }
 
   /**

--- a/src/server/modules/api/trade/trade.resolver.ts
+++ b/src/server/modules/api/trade/trade.resolver.ts
@@ -105,8 +105,7 @@ export class TradeResolver {
     this.logger.info('Buy quote received', {
       assetAmount: input.assetAmount,
       sats,
-      rfqId: quote?.id ? Buffer.from(quote.id).toString('hex') : undefined,
-      expiry: quote?.expiry,
+      rfqId: Buffer.from(quote.id).toString('hex'),
       quote,
     });
 
@@ -198,23 +197,36 @@ export class TradeResolver {
       throw new GraphQLError('Failed to decode asset invoice');
     }
 
-    await this.assertBtcLiquidity(
-      id,
-      input.peerPubkey,
-      decoded.tokens,
-      'local'
+    const btcChannels = await this.getBtcChannelsWithPeer(id, input.peerPubkey);
+
+    if (btcChannels.length === 0) {
+      throw new GraphQLError(
+        'No active BTC channel with trade partner — cannot execute trade'
+      );
+    }
+
+    const sortedByLocal = [...btcChannels].sort(
+      (a, b) => b.local_balance - a.local_balance
     );
+    const bestChannel = sortedByLocal[0];
+
+    if (bestChannel.local_balance < decoded.tokens) {
+      throw new GraphQLError(
+        `Insufficient outbound BTC liquidity with trade partner: need ${decoded.tokens} sats, have ${bestChannel.local_balance} sats`
+      );
+    }
 
     this.logger.info('Executing buy trade', {
       assetAmount: input.assetAmount,
-      invoicePrefix: paymentRequest.slice(0, 20),
+      invoicePrefix: paymentRequest,
+      outgoingChannel: bestChannel.id,
     });
 
     const [payResult, payError] = await toWithError(
       this.nodeService.pay(id, {
         request: paymentRequest,
         is_allow_self_payment: true,
-        max_fee: 1000,
+        outgoing_channel: bestChannel.id,
       })
     );
 
@@ -435,7 +447,9 @@ export class TradeResolver {
   private async getBtcChannelsWithPeer(
     id: string,
     peerPubkey: string
-  ): Promise<Array<{ local_balance: number; remote_balance: number }>> {
+  ): Promise<
+    Array<{ id: string; local_balance: number; remote_balance: number }>
+  > {
     const [channelsResult, channelsError] = await toWithError(
       this.nodeService.getChannels(id, {
         partner_public_key: peerPubkey,
@@ -449,7 +463,7 @@ export class TradeResolver {
 
     return channelsResult.channels.filter(
       (ch: { type?: string }) => !!ch.type
-    ) as Array<{ local_balance: number; remote_balance: number }>;
+    ) as Array<{ id: string; local_balance: number; remote_balance: number }>;
   }
 
   /**

--- a/src/server/modules/api/trade/trade.resolver.ts
+++ b/src/server/modules/api/trade/trade.resolver.ts
@@ -77,7 +77,7 @@ export class TradeResolver {
         groupKey: input.tapdGroupKey || undefined,
         assetAmount: input.assetAmount,
         peerPubkey: input.peerPubkey,
-        expiry: 30,
+        expiry: input.expiry ?? 30,
       })
     );
 

--- a/src/server/modules/api/trade/trade.resolver.ts
+++ b/src/server/modules/api/trade/trade.resolver.ts
@@ -19,6 +19,7 @@ import {
 
 const HEX_PUBKEY_RE = /^[0-9a-f]{66}$/;
 const HEX_ASSET_ID_RE = /^[0-9a-f]{64}$/;
+const DEFAULT_INVOICE_EXPIRY_SEC = 30;
 
 @Resolver()
 export class TradeResolver {
@@ -77,7 +78,7 @@ export class TradeResolver {
         groupKey: input.tapdGroupKey || undefined,
         assetAmount: input.assetAmount,
         peerPubkey: input.peerPubkey,
-        expiry: input.expiry ?? 30,
+        expiry: input.expiry ?? DEFAULT_INVOICE_EXPIRY_SEC,
       })
     );
 
@@ -266,12 +267,19 @@ export class TradeResolver {
     const [
       [heightResult, heightError],
       [identity, identityError],
-      [channelInfo],
+      [channelInfo, channelInfoError],
     ] = await Promise.all([
       toWithError(this.nodeService.getHeight(id)),
       toWithError(this.nodeService.getIdentity(id)),
       toWithError(this.nodeService.getChannel(id, btcChannel.id)),
     ]);
+
+    if (channelInfoError) {
+      this.logger.warn(
+        'Could not fetch channel info for fee estimation; using defaults',
+        { error: channelInfoError, channelId: btcChannel.id }
+      );
+    }
 
     if (heightError || !heightResult?.current_block_height) {
       throw new GraphQLError('Failed to get current block height');
@@ -437,19 +445,33 @@ export class TradeResolver {
       throw new GraphQLError('Derived sats amount is zero or negative');
     }
 
-    // Self-payment loop: assets leave via the TA channel (forced first hop by
-    // tapd/RFQ) and the sats return leg comes back via the BTC channel. If we
-    // let LND auto-include private channel hints (is_including_private_channels),
-    // the TA channel also gets advertised — htlcswitch then rejects the forward
-    // with "same incoming and outgoing channel" because tapd already picked the
-    // TA channel for the outgoing hop. Build an explicit BTC-only route hint
-    // instead so pathfinding only sees the valid return path.
-    const btcHopHint = await this.buildBtcReturnHint(id, input.peerPubkey);
+    // Fetch BTC channels once for both the return-hint and the liquidity check.
+    const btcChannels = await this.getBtcChannelsWithPeer(id, input.peerPubkey);
+    if (btcChannels.length === 0) {
+      throw new GraphQLError(
+        'No active BTC channel with trade partner — cannot execute trade'
+      );
+    }
 
-    // For sells, the sats return leg comes from the peer's local balance (our
-    // remote). Check that up front so we fail with a clear message instead of
-    // triggering a routing failure partway through.
-    await this.assertBtcLiquidity(id, input.peerPubkey, invoiceSats, 'remote');
+    const maxRemote = btcChannels.reduce(
+      (max, ch) => (ch.remote_balance > max ? ch.remote_balance : max),
+      0
+    );
+    if (maxRemote < invoiceSats) {
+      throw new GraphQLError(
+        `Insufficient inbound BTC liquidity with trade partner: need ${invoiceSats} sats, have ${maxRemote} sats`
+      );
+    }
+
+    // Self-payment loop: assets leave via the TA channel (forced first hop by
+    // tapd/RFQ) and the sats return leg comes back via the BTC channel. Build
+    // an explicit BTC-only route hint so pathfinding only sees the valid return
+    // path — omitting TA channels prevents "same incoming and outgoing channel".
+    const btcHopHint = await this.buildBtcReturnHint(
+      id,
+      input.peerPubkey,
+      btcChannels
+    );
 
     const [invoice, invoiceError] = await toWithError(
       this.nodeService.createInvoice(id, {
@@ -507,20 +529,23 @@ export class TradeResolver {
    */
   private async buildBtcReturnHint(
     id: string,
-    peerPubkey: string
+    peerPubkey: string,
+    btcChannels: Array<{
+      id: string;
+      capacity: number;
+      local_balance: number;
+      remote_balance: number;
+    }>
   ): Promise<Route | undefined> {
-    const [channelsResult, channelsError] = await toWithError(
-      this.nodeService.getChannels(id, {
-        partner_public_key: peerPubkey,
-        is_active: true,
-      })
+    const sorted = [...btcChannels].sort(
+      (a, b) => b.remote_balance - a.remote_balance
     );
+    const btcChannel = sorted[0];
 
-    if (channelsError || !channelsResult?.channels?.length) {
-      this.logger.warn(
-        'Could not fetch channels for BTC return hint; omitting hint',
-        { error: channelsError, peerPubkey }
-      );
+    if (!btcChannel) {
+      this.logger.warn('No BTC channel with peer; omitting return hint', {
+        peerPubkey,
+      });
       return undefined;
     }
 
@@ -531,29 +556,6 @@ export class TradeResolver {
     if (identityError || !identity?.public_key) {
       this.logger.warn('Could not fetch identity for return hint; omitting', {
         error: identityError,
-      });
-      return undefined;
-    }
-
-    // Taproot Asset channels use LND's SIMPLE_TAPROOT_OVERLAY commitment type,
-    // which the `lightning` package does not map — it leaves `type` undefined.
-    // BTC channels map to "anchor", "simplified_taproot", etc. Filtering by a
-    // truthy `type` isolates BTC channels. Sort by `remote_balance` descending
-    // so the return leg uses the channel with the most peer-side capacity.
-    const btcChannels = channelsResult.channels
-      .filter(
-        (ch: { type?: string; id: string; remote_balance: number }) => !!ch.type
-      )
-      .sort(
-        (a: { remote_balance: number }, b: { remote_balance: number }) =>
-          b.remote_balance - a.remote_balance
-      );
-
-    const btcChannel = btcChannels[0];
-
-    if (!btcChannel) {
-      this.logger.warn('No BTC channel with peer; omitting return hint', {
-        peerPubkey,
       });
       return undefined;
     }
@@ -582,12 +584,8 @@ export class TradeResolver {
     ];
   }
 
-  /*
-   * Finds all active BTC channels with the given peer. Taproot Asset channels
-   * use SIMPLE_TAPROOT_OVERLAY, which the `lightning` package does not map —
-   * it leaves `type` undefined. BTC channels map to "anchor",
-   * "simplified_taproot", etc. Filtering by a truthy `type` isolates BTC.
-   */
+  // Filters by truthy `type` — SIMPLE_TAPROOT_OVERLAY stays undefined in the
+  // `lightning` package, so TA channels are excluded while BTC channels pass.
   private async getBtcChannelsWithPeer(
     id: string,
     peerPubkey: string
@@ -606,6 +604,13 @@ export class TradeResolver {
       })
     );
 
+    if (channelsError) {
+      this.logger.warn('Failed to fetch channels with peer', {
+        error: channelsError,
+        peerPubkey,
+      });
+    }
+
     if (channelsError || !channelsResult?.channels?.length) {
       return [];
     }
@@ -618,43 +623,6 @@ export class TradeResolver {
       local_balance: number;
       remote_balance: number;
     }>;
-  }
-
-  /**
-   * Pre-flight BTC liquidity check for the self-payment trade loop. A single
-   * Lightning payment has to flow through one channel, so we compare against
-   * the biggest balance across BTC channels with the peer (not the sum).
-   * - 'local': the trader needs enough outbound (their balance) to pay sats
-   *   out — used for buys.
-   * - 'remote': the trader needs enough inbound (peer's balance) to receive
-   *   the sats leg back — used for sells.
-   */
-  private async assertBtcLiquidity(
-    id: string,
-    peerPubkey: string,
-    requiredSats: number,
-    direction: 'local' | 'remote'
-  ): Promise<void> {
-    const channels = await this.getBtcChannelsWithPeer(id, peerPubkey);
-
-    if (channels.length === 0) {
-      throw new GraphQLError(
-        'No active BTC channel with trade partner — cannot execute trade'
-      );
-    }
-
-    const available = channels.reduce((max, ch) => {
-      const balance =
-        direction === 'local' ? ch.local_balance : ch.remote_balance;
-      return balance > max ? balance : max;
-    }, 0);
-
-    if (available < requiredSats) {
-      const label = direction === 'local' ? 'outbound' : 'inbound';
-      throw new GraphQLError(
-        `Insufficient ${label} BTC liquidity with trade partner: need ${requiredSats} sats, have ${available} sats`
-      );
-    }
   }
 
   /**

--- a/src/server/modules/api/trade/trade.types.ts
+++ b/src/server/modules/api/trade/trade.types.ts
@@ -17,6 +17,9 @@ export class TradeQuoteInput {
 
   @Field()
   peerPubkey: string;
+
+  @Field({ nullable: true })
+  expiry?: number;
 }
 
 @ObjectType()

--- a/src/server/modules/node/lightning.types.ts
+++ b/src/server/modules/node/lightning.types.ts
@@ -103,6 +103,34 @@ export type PayViaPaymentDetailsOptions = {
   messages?: { type: string; value: string }[];
 };
 
+export type PayViaRoutesHop = {
+  channel: string;
+  channel_capacity: number;
+  fee: number;
+  fee_mtokens: string;
+  forward: number;
+  forward_mtokens: string;
+  public_key?: string;
+  timeout: number;
+  messages?: { type: string; value: string }[];
+};
+
+export type PayViaRoutesRoute = {
+  fee: number;
+  fee_mtokens: string;
+  hops: PayViaRoutesHop[];
+  mtokens: string;
+  payment?: string;
+  timeout: number;
+  tokens: number;
+  total_mtokens?: string;
+};
+
+export type PayViaRoutesOptions = {
+  id?: string;
+  routes: PayViaRoutesRoute[];
+};
+
 export type SendToChainAddressOptions = {
   address: string;
   tokens?: number;
@@ -207,6 +235,7 @@ export interface LightningProvider {
     connection: any,
     options: PayViaPaymentDetailsOptions
   ): Promise<any>;
+  payViaRoutes(connection: any, options: PayViaRoutesOptions): Promise<any>;
   decodePaymentRequest(connection: any, request: string): Promise<any>;
   getPayments(connection: any, options: GetPaymentsOptions): Promise<any>;
 

--- a/src/server/modules/node/litd/litd.service.ts
+++ b/src/server/modules/node/litd/litd.service.ts
@@ -14,6 +14,7 @@ import {
   PayOptions,
   CreateInvoiceOptions,
   PayViaPaymentDetailsOptions,
+  PayViaRoutesOptions,
   SendToChainAddressOptions,
   CreateChainAddressFormat,
   UpdateRoutingFeesOptions,
@@ -185,6 +186,10 @@ export class LitdService implements LightningProvider, TaprootAssetsProvider {
       this.getLnd(connection),
       options
     );
+  }
+
+  async payViaRoutes(connection: LitdConnection, options: PayViaRoutesOptions) {
+    return this.lndService.payViaRoutes(this.getLnd(connection), options);
   }
 
   async decodePaymentRequest(connection: LitdConnection, request: string) {

--- a/src/server/modules/node/lnd/lnd.service.ts
+++ b/src/server/modules/node/lnd/lnd.service.ts
@@ -316,6 +316,8 @@ export class LndService implements LightningProvider {
     return to(payViaPaymentDetails({ lnd, ...options } as any));
   }
 
+  // Intentionally not wrapped in to() — callers need the raw [code, message,
+  // {failures}] array that payViaRoutes throws on failure for diagnostics.
   async payViaRoutes(lnd: AuthenticatedLnd, options: PayViaRoutesOptions) {
     return payViaRoutes({ lnd, ...options } as any);
   }

--- a/src/server/modules/node/lnd/lnd.service.ts
+++ b/src/server/modules/node/lnd/lnd.service.ts
@@ -29,6 +29,7 @@ import {
   decodePaymentRequest,
   pay,
   payViaPaymentDetails,
+  payViaRoutes,
   createInvoice,
   getChannel,
   closeChannel,
@@ -57,6 +58,7 @@ import {
   PayOptions,
   CreateInvoiceOptions,
   PayViaPaymentDetailsOptions,
+  PayViaRoutesOptions,
   SendToChainAddressOptions,
   CreateChainAddressFormat,
   UpdateRoutingFeesOptions,
@@ -312,6 +314,10 @@ export class LndService implements LightningProvider {
     options: PayViaPaymentDetailsOptions
   ) {
     return to(payViaPaymentDetails({ lnd, ...options } as any));
+  }
+
+  async payViaRoutes(lnd: AuthenticatedLnd, options: PayViaRoutesOptions) {
+    return payViaRoutes({ lnd, ...options } as any);
   }
 
   subscribeToInvoice(lnd: AuthenticatedLnd, id: string): EventEmitter {

--- a/src/server/modules/node/node.service.ts
+++ b/src/server/modules/node/node.service.ts
@@ -23,6 +23,7 @@ import {
   OpenChannelOptions,
   PayOptions,
   PayViaPaymentDetailsOptions,
+  PayViaRoutesOptions,
   SendToChainAddressOptions,
   UpdateRoutingFeesOptions,
   VerifyBackupsOptions,
@@ -264,6 +265,11 @@ export class NodeService {
   async payViaPaymentDetails(id: string, options: PayViaPaymentDetailsOptions) {
     const { account, provider } = this.getAccountAndProvider(id);
     return provider.payViaPaymentDetails(account.connection, options);
+  }
+
+  async payViaRoutes(id: string, options: PayViaRoutesOptions) {
+    const { account, provider } = this.getAccountAndProvider(id);
+    return provider.payViaRoutes(account.connection, options);
   }
 
   subscribeToInvoice(id: string, invoice: string): EventEmitter {


### PR DESCRIPTION
## Summary

- Use `payViaRoutes` with an explicit 2-hop route to force LND through tapd's virtual SCID, since LND's pathfinder skips the RFQ virtual channel
- Route construction: sender → peer (BTC channel) → sender (virtual SCID)
- Extract the virtual SCID from BOLT11 route hints embedded by `addAssetInvoice`
- Compute CLTV timeouts and routing fees from the peer's channel policy
- Validate that the peer's accepted asset amount matches the requested amount before executing the trade
- Add `payViaRoutes` to the `LightningProvider` interface and all implementations (LND, LiTD, NodeService)
- Preserve raw `payViaRoutes` error details (bypassing the `to()` helper) for debugging CLTV/routing failures

## Test plan

- [x] Execute a buy trade — verify payment routes through virtual SCID and completes
- [ ] Execute a buy trade with no BTC channel to the partner — verify "No active BTC channel" error
- [ ] Execute a buy trade with insufficient outbound liquidity — verify clear error message
- [ ] Execute a buy trade where peer accepts fewer assets than requested — verify early rejection
- [ ] Verify existing tests pass (`pnpm run test`)