### PR TITLE
feat: add tapd daemon info to advanced assets view

### DIFF
--- a/schema.gql
+++ b/schema.gql
@@ -991,6 +991,17 @@ type TapBalances {
   balances: [TapAssetBalanceEntry!]!
 }
 
+type TapDaemonInfo {
+  block_hash: String!
+  block_height: Int!
+  lnd_identity_pubkey: String!
+  lnd_version: String!
+  network: String!
+  node_alias: String!
+  sync_to_chain: Boolean!
+  version: String!
+}
+
 type TapFederationServer {
   host: String!
   id: Int!
@@ -1162,6 +1173,7 @@ type TaprootAssetsQueries {
   get_assets: TapAssetList!
   get_balances(group_by: TapBalanceGroupBy = GROUP_KEY): TapBalances!
   get_federation_servers: TapFederationServerList!
+  get_info: TapDaemonInfo!
   get_transfers: TapTransferList!
   get_universe_assets: TapUniverseAssetList!
   get_universe_info: TapUniverseInfo!

--- a/src/client/src/graphql/queries/__generated__/getTapInfo.generated.tsx
+++ b/src/client/src/graphql/queries/__generated__/getTapInfo.generated.tsx
@@ -1,0 +1,131 @@
+import * as Types from '../../types';
+
+import { gql } from '@apollo/client';
+import * as Apollo from '@apollo/client';
+const defaultOptions = {} as const;
+export type GetTapInfoQueryVariables = Types.Exact<{
+  [key: string]: never;
+}>;
+
+export type GetTapInfoQuery = {
+  __typename?: 'Query';
+  taproot_assets: {
+    __typename?: 'TaprootAssetsQueries';
+    id: string;
+    get_info: {
+      __typename?: 'TapDaemonInfo';
+      version: string;
+      lnd_version: string;
+      network: string;
+      lnd_identity_pubkey: string;
+      node_alias: string;
+      block_height: number;
+      block_hash: string;
+      sync_to_chain: boolean;
+    };
+  };
+};
+
+export const GetTapInfoDocument = gql`
+  query GetTapInfo {
+    taproot_assets {
+      id
+      get_info {
+        version
+        lnd_version
+        network
+        lnd_identity_pubkey
+        node_alias
+        block_height
+        block_hash
+        sync_to_chain
+      }
+    }
+  }
+`;
+
+/**
+ * __useGetTapInfoQuery__
+ *
+ * To run a query within a React component, call `useGetTapInfoQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetTapInfoQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetTapInfoQuery({
+ *   variables: {
+ *   },
+ * });
+ */
+export function useGetTapInfoQuery(
+  baseOptions?: Apollo.QueryHookOptions<
+    GetTapInfoQuery,
+    GetTapInfoQueryVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<GetTapInfoQuery, GetTapInfoQueryVariables>(
+    GetTapInfoDocument,
+    options
+  );
+}
+export function useGetTapInfoLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    GetTapInfoQuery,
+    GetTapInfoQueryVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<GetTapInfoQuery, GetTapInfoQueryVariables>(
+    GetTapInfoDocument,
+    options
+  );
+}
+// @ts-ignore
+export function useGetTapInfoSuspenseQuery(
+  baseOptions?: Apollo.SuspenseQueryHookOptions<
+    GetTapInfoQuery,
+    GetTapInfoQueryVariables
+  >
+): Apollo.UseSuspenseQueryResult<GetTapInfoQuery, GetTapInfoQueryVariables>;
+export function useGetTapInfoSuspenseQuery(
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<
+        GetTapInfoQuery,
+        GetTapInfoQueryVariables
+      >
+): Apollo.UseSuspenseQueryResult<
+  GetTapInfoQuery | undefined,
+  GetTapInfoQueryVariables
+>;
+export function useGetTapInfoSuspenseQuery(
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<
+        GetTapInfoQuery,
+        GetTapInfoQueryVariables
+      >
+) {
+  const options =
+    baseOptions === Apollo.skipToken
+      ? baseOptions
+      : { ...defaultOptions, ...baseOptions };
+  return Apollo.useSuspenseQuery<GetTapInfoQuery, GetTapInfoQueryVariables>(
+    GetTapInfoDocument,
+    options
+  );
+}
+export type GetTapInfoQueryHookResult = ReturnType<typeof useGetTapInfoQuery>;
+export type GetTapInfoLazyQueryHookResult = ReturnType<
+  typeof useGetTapInfoLazyQuery
+>;
+export type GetTapInfoSuspenseQueryHookResult = ReturnType<
+  typeof useGetTapInfoSuspenseQuery
+>;
+export type GetTapInfoQueryResult = Apollo.QueryResult<
+  GetTapInfoQuery,
+  GetTapInfoQueryVariables
+>;

--- a/src/client/src/graphql/queries/getTapInfo.ts
+++ b/src/client/src/graphql/queries/getTapInfo.ts
@@ -1,0 +1,19 @@
+import { gql } from '@apollo/client';
+
+export const GET_TAP_INFO = gql`
+  query GetTapInfo {
+    taproot_assets {
+      id
+      get_info {
+        version
+        lnd_version
+        network
+        lnd_identity_pubkey
+        node_alias
+        block_height
+        block_hash
+        sync_to_chain
+      }
+    }
+  }
+`;

--- a/src/client/src/views/assets/TapDaemonInfo.tsx
+++ b/src/client/src/views/assets/TapDaemonInfo.tsx
@@ -1,0 +1,76 @@
+import { FC } from 'react';
+import { Loader2, Info, CheckCircle2, XCircle } from 'lucide-react';
+import { Card, CardContent } from '@/components/ui/card';
+import { useGetTapInfoQuery } from '../../graphql/queries/__generated__/getTapInfo.generated';
+
+export const TapDaemonInfo: FC = () => {
+  const { data, loading, error } = useGetTapInfoQuery({
+    fetchPolicy: 'cache-and-network',
+  });
+
+  if (loading) {
+    return (
+      <div className="flex items-center gap-2 text-sm text-muted-foreground">
+        <Loader2 size={14} className="animate-spin" />
+        Loading daemon info...
+      </div>
+    );
+  }
+
+  if (error || !data?.taproot_assets?.get_info) {
+    return (
+      <div className="text-sm text-muted-foreground">
+        Daemon info unavailable
+      </div>
+    );
+  }
+
+  const info = data.taproot_assets.get_info;
+
+  const rows: { label: string; value: string | number | boolean }[] = [
+    { label: 'Version', value: info.version },
+    { label: 'LND Version', value: info.lnd_version },
+    { label: 'Network', value: info.network },
+    { label: 'Node Alias', value: info.node_alias },
+    { label: 'Identity Pubkey', value: info.lnd_identity_pubkey },
+    { label: 'Block Height', value: info.block_height },
+    { label: 'Block Hash', value: info.block_hash },
+    { label: 'Synced to Chain', value: info.sync_to_chain },
+  ];
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex items-center gap-2">
+        <Info size={16} className="text-muted-foreground" />
+        <h3 className="text-sm font-semibold">Daemon Info</h3>
+      </div>
+      <Card>
+        <CardContent className="p-4">
+          <div className="grid gap-3">
+            {rows.map(row => (
+              <div
+                key={row.label}
+                className="flex items-start justify-between gap-4 text-sm"
+              >
+                <span className="text-muted-foreground shrink-0">
+                  {row.label}
+                </span>
+                {typeof row.value === 'boolean' ? (
+                  row.value ? (
+                    <CheckCircle2 size={16} className="text-green-500" />
+                  ) : (
+                    <XCircle size={16} className="text-red-500" />
+                  )
+                ) : (
+                  <span className="font-mono text-right break-all">
+                    {row.value}
+                  </span>
+                )}
+              </div>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+};

--- a/src/client/src/views/assets/TapDaemonInfo.tsx
+++ b/src/client/src/views/assets/TapDaemonInfo.tsx
@@ -8,7 +8,7 @@ export const TapDaemonInfo: FC = () => {
     fetchPolicy: 'cache-and-network',
   });
 
-  if (loading) {
+  if (loading && !data) {
     return (
       <div className="flex items-center gap-2 text-sm text-muted-foreground">
         <Loader2 size={14} className="animate-spin" />

--- a/src/client/src/views/assets/index.tsx
+++ b/src/client/src/views/assets/index.tsx
@@ -8,6 +8,7 @@ import { ReceiveAsset } from './ReceiveAsset';
 import { AssetTransfers } from './AssetTransfers';
 import { FundAssetChannel } from './FundAssetChannel';
 import { UniverseManager } from './UniverseManager';
+import { TapDaemonInfo } from './TapDaemonInfo';
 import { cn } from '../../lib/utils';
 
 type Tab =
@@ -70,6 +71,8 @@ export const AssetsView = () => {
           <BurnAsset />
           <div className="h-px bg-border" />
           <UniverseManager />
+          <div className="h-px bg-border" />
+          <TapDaemonInfo />
         </div>
       )}
     </div>

--- a/src/server/modules/api/tapd/tapd.resolver.spec.ts
+++ b/src/server/modules/api/tapd/tapd.resolver.spec.ts
@@ -37,6 +37,7 @@ const mockService = () => ({
   addAssetInvoice: jest.fn(),
   fundAssetChannel: jest.fn(),
   getAccount: jest.fn(),
+  getInfo: jest.fn(),
 });
 
 type MockService = ReturnType<typeof mockService>;
@@ -55,6 +56,39 @@ describe('TaprootAssetsQueriesResolver', () => {
       service as never,
       mockLogger as never
     );
+  });
+
+  describe('get_info', () => {
+    it('returns mapped daemon info fields', async () => {
+      service.getInfo.mockResolvedValue({
+        version: '0.4.0',
+        lndVersion: '0.18.0',
+        network: 'testnet',
+        lndIdentityPubkey: 'abc123',
+        nodeAlias: 'test-node',
+        blockHeight: 800000,
+        blockHash: 'deadbeef',
+        syncToChain: true,
+      });
+
+      const result = await resolver.get_info(userId);
+
+      expect(result).toEqual({
+        version: '0.4.0',
+        lnd_version: '0.18.0',
+        network: 'testnet',
+        lnd_identity_pubkey: 'abc123',
+        node_alias: 'test-node',
+        block_height: 800000,
+        block_hash: 'deadbeef',
+        sync_to_chain: true,
+      });
+    });
+
+    it('throws GraphQLError when the service call fails', async () => {
+      service.getInfo.mockRejectedValue(new Error('connection failed'));
+      await expect(resolver.get_info(userId)).rejects.toThrow(GraphQLError);
+    });
   });
 
   describe('get_assets', () => {

--- a/src/server/modules/api/tapd/tapd.resolver.ts
+++ b/src/server/modules/api/tapd/tapd.resolver.ts
@@ -27,6 +27,7 @@ import {
   TapTransferList,
   TapUniverseInfo,
   TapUniverseStats,
+  TapDaemonInfo,
   TaprootAssetsMutations,
   TaprootAssetsQueries,
 } from './tapd.types';
@@ -106,6 +107,29 @@ export class TaprootAssetsQueriesResolver {
   @ResolveField(() => String)
   id(): string {
     return uuidv5(TaprootAssetsQueriesResolver.name, uuidv5.URL);
+  }
+
+  @ResolveField(() => TapDaemonInfo)
+  async get_info(@CurrentUser() { id }: UserId) {
+    const [result, error] = await toWithError(
+      this.tapdNodeService.getInfo({ id })
+    );
+    if (error || !result) {
+      this.logger.error('Failed to get tapd info', { error });
+      throw new GraphQLError(
+        grpcErrorMessage('Failed to get tapd info', error)
+      );
+    }
+    return {
+      version: result.version || '',
+      lnd_version: result.lndVersion || '',
+      network: result.network || '',
+      lnd_identity_pubkey: result.lndIdentityPubkey || '',
+      node_alias: result.nodeAlias || '',
+      block_height: result.blockHeight ?? 0,
+      block_hash: result.blockHash || '',
+      sync_to_chain: result.syncToChain ?? false,
+    };
   }
 
   @ResolveField(() => TapAssetList)

--- a/src/server/modules/api/tapd/tapd.types.ts
+++ b/src/server/modules/api/tapd/tapd.types.ts
@@ -205,6 +205,35 @@ export class TapFinalizeBatchResponse {
   batch_key: string;
 }
 
+// ─── Daemon Info ───────────────────────────────────────────────
+
+@ObjectType()
+export class TapDaemonInfo {
+  @Field()
+  version: string;
+
+  @Field()
+  lnd_version: string;
+
+  @Field()
+  network: string;
+
+  @Field()
+  lnd_identity_pubkey: string;
+
+  @Field()
+  node_alias: string;
+
+  @Field(() => Int)
+  block_height: number;
+
+  @Field()
+  block_hash: string;
+
+  @Field()
+  sync_to_chain: boolean;
+}
+
 // ─── Universe ───────────────────────────────────────────────────
 
 @ObjectType()

--- a/src/server/modules/node/tapd/tapd-node.service.ts
+++ b/src/server/modules/node/tapd/tapd-node.service.ts
@@ -29,6 +29,7 @@ import {
   UniverseAssetStats,
   AddFederationServerResponse,
 } from '@lightningpolar/tapd-api';
+import { GetInfoResponse as TapGetInfoResponse } from '@lightningpolar/tapd-api/dist/types/taprpc/GetInfoResponse';
 import { AddInvoiceResponse as TapAddInvoiceResponse } from '@lightningpolar/tapd-api/dist/types/tapchannelrpc/AddInvoiceResponse';
 import { Payment as LnrpcPayment } from '@lightningpolar/tapd-api/dist/types/lnrpc/Payment';
 import { AccountsService } from '../../accounts/accounts.service';
@@ -85,6 +86,17 @@ export class TapdNodeService {
     }
 
     return tapd;
+  }
+
+  // ── Info ──
+
+  async getInfo(opts: { id: string }): Promise<TapGetInfoResponse> {
+    const tapd = this.getTapd(opts.id);
+    // The barrel export resolves GetInfoResponse to lnrpc's variant, but
+    // taprootAssets.getInfo() actually returns taprpc.GetInfoResponse at runtime.
+    return tapd.taprootAssets.getInfo(
+      {}
+    ) as unknown as Promise<TapGetInfoResponse>;
   }
 
   // ── Assets ──

--- a/src/server/modules/node/tapd/tapd-node.service.ts
+++ b/src/server/modules/node/tapd/tapd-node.service.ts
@@ -94,9 +94,9 @@ export class TapdNodeService {
     const tapd = this.getTapd(opts.id);
     // The barrel export resolves GetInfoResponse to lnrpc's variant, but
     // taprootAssets.getInfo() actually returns taprpc.GetInfoResponse at runtime.
-    return tapd.taprootAssets.getInfo(
-      {}
-    ) as unknown as Promise<TapGetInfoResponse>;
+    const result = await tapd.taprootAssets.getInfo({});
+
+    return result as unknown as TapGetInfoResponse;
   }
 
   // ── Assets ──


### PR DESCRIPTION
## Summary
- Add `get_info` GraphQL query field on `taproot_assets` that calls `tapd.taprootAssets.getInfo()` (equivalent of `tapcli getinfo`)
- New `TapDaemonInfo` component showing version, LND version, network, node alias, identity pubkey, block height, block hash, and chain sync status
- Displayed at the bottom of the Advanced tab in the Taproot Assets view

## Test plan
- [ ] Navigate to Taproot Assets → Advanced tab and verify the Daemon Info section appears at the bottom
- [ ] Confirm all fields (version, network, block height, etc.) display correctly
- [ ] Verify "Daemon info unavailable" shows when tapd is unreachable
- [ ] Verify block height updates on tab re-visits (uses `cache-and-network` fetch policy)
- [ ] Run `npm run generate` to regenerate the typed client code from the running server