### PR TITLE
feat: private channels for asset magma orders

### DIFF
--- a/src/server/modules/api/magma/magma.resolver.spec.ts
+++ b/src/server/modules/api/magma/magma.resolver.spec.ts
@@ -367,7 +367,7 @@ describe('MagmaResolver', () => {
           magmaUrl,
           expect.anything(),
           expect.objectContaining({
-            input: expect.objectContaining({ size: '1000' }),
+            input: expect.objectContaining({ size: '1000', is_private: true }),
           }),
           expect.any(Object)
         );
@@ -433,7 +433,7 @@ describe('MagmaResolver', () => {
           magmaUrl,
           expect.anything(),
           expect.objectContaining({
-            input: expect.objectContaining({ size: '1000' }),
+            input: expect.objectContaining({ size: '1000', is_private: true }),
           }),
           expect.any(Object)
         );

--- a/src/server/modules/api/magma/magma.resolver.ts
+++ b/src/server/modules/api/magma/magma.resolver.ts
@@ -222,6 +222,7 @@ export class MagmaResolver {
                   pubkey: nodeInfo.publicKey,
                   size: magmaSize,
                   payment_method: 'SATS',
+                  is_private: true,
                   options: { asset_id: input.ambossAssetId },
                 },
               },


### PR DESCRIPTION
## Summary
- Always set `is_private: true` when creating Magma orders for asset channels

## Test plan
- [x] Existing magma resolver tests updated and passing
- [ ] Verify Magma order is created with `is_private: true` in staging