### PR TITLE
Show asset balances in the channels table.

### DIFF
--- a/schema.gql
+++ b/schema.gql
@@ -171,6 +171,7 @@ type Channel {
 
 type ChannelAsset {
   assetId: String!
+  assetName: String!
   capacity: String!
   groupKey: String
   localBalance: String!

--- a/schema.gql
+++ b/schema.gql
@@ -170,12 +170,14 @@ type Channel {
 }
 
 type ChannelAsset {
-  assetId: String!
-  assetName: String!
+  asset_id: String!
+  asset_name: String!
+  asset_precision: Float!
+  asset_type: String!
   capacity: String!
-  groupKey: String
-  localBalance: String!
-  remoteBalance: String!
+  group_key: String
+  local_balance: String!
+  remote_balance: String!
 }
 
 type ChannelInfo {

--- a/src/client/src/components/balance/index.tsx
+++ b/src/client/src/components/balance/index.tsx
@@ -9,6 +9,8 @@ type BalanceProps = {
   formatRemote?: JSX.Element | string;
   height?: number;
   withBorderColor?: boolean;
+  localColor?: string;
+  remoteColor?: string;
 };
 
 export const BalanceBars = ({
@@ -18,6 +20,8 @@ export const BalanceBars = ({
   formatRemote,
   height = 20,
   withBorderColor = false,
+  localColor,
+  remoteColor,
 }: BalanceProps) => {
   const localOpposite = 100 - local;
   const remoteOpposite = 100 - remote;
@@ -51,8 +55,18 @@ export const BalanceBars = ({
         </div>
       )}
       <ProgressBar barHeight={height} order={4} percent={localOpposite} />
-      <ProgressBar barHeight={height} order={1} percent={local} />
-      <ProgressBar barHeight={height} order={2} percent={remote} />
+      <ProgressBar
+        barHeight={height}
+        order={1}
+        percent={local}
+        style={localColor ? { backgroundColor: localColor } : undefined}
+      />
+      <ProgressBar
+        barHeight={height}
+        order={2}
+        percent={remote}
+        style={remoteColor ? { backgroundColor: remoteColor } : undefined}
+      />
       <ProgressBar barHeight={height} order={4} percent={remoteOpposite} />
     </div>
   );

--- a/src/client/src/components/generic/CardGeneric.tsx
+++ b/src/client/src/components/generic/CardGeneric.tsx
@@ -13,13 +13,13 @@ export const Progress = forwardRef<
 // ─── ProgressBar ─────────────────────────────────────────
 
 const chartColors = {
-  purple: '#6938f1',
-  lightblue: '#1890ff',
-  green: '#a0d911',
-  orange: '#ffa940',
-  orange2: '#FD5F00',
-  darkyellow: '#ffd300',
-  red: 'red',
+  purple: 'rgba(105, 56, 241, 0.8)',
+  lightblue: 'rgba(24, 144, 255, 0.8)',
+  green: 'rgba(160, 217, 17, 0.8)',
+  orange: 'rgba(255, 169, 64, 0.8)',
+  orange2: 'rgba(253, 95, 0, 0.8)',
+  darkyellow: 'rgba(255, 211, 0, 0.8)',
+  red: 'rgba(255, 0, 0, 0.8)',
 };
 
 const orderColors: Record<number, string | null> = {

--- a/src/client/src/components/table/ColumnConfigurations.tsx
+++ b/src/client/src/components/table/ColumnConfigurations.tsx
@@ -20,13 +20,20 @@ export const ColumnConfigurations: FC<ColumnConfigurationsProps> = ({
     return grouped;
   }, [table]);
 
+  const groupLabel = (groupId: string): string => {
+    if (groupId === 'undefined') return 'General';
+    const col = table.getColumn(groupId);
+    const header = col?.columnDef?.header;
+    return typeof header === 'string' ? header : groupId;
+  };
+
   return (
     <div className="flex flex-wrap gap-4 rounded border border-border p-3">
       {Object.keys(groupedHideableColumns).map(
         (group: string, index: number) => (
           <div key={`${group}-${index}`} className="flex flex-col gap-1.5">
             <span className="text-xs font-medium text-muted-foreground">
-              {group === 'undefined' ? 'General' : group}
+              {groupLabel(group)}
             </span>
             <div className="flex flex-col gap-1">
               {groupedHideableColumns[group].map((column: any) => {

--- a/src/client/src/graphql/queries/__generated__/getChannels.generated.tsx
+++ b/src/client/src/graphql/queries/__generated__/getChannels.generated.tsx
@@ -66,6 +66,14 @@ export type GetChannelsQuery = {
         min_htlc_mtokens?: string | null;
       } | null;
     } | null;
+    asset?: {
+      __typename?: 'ChannelAsset';
+      assetId: string;
+      assetName: string;
+      localBalance: string;
+      remoteBalance: string;
+      capacity: string;
+    } | null;
   }>;
 };
 
@@ -140,6 +148,13 @@ export const GetChannelsDocument = gql`
           max_htlc_mtokens
           min_htlc_mtokens
         }
+      }
+      asset {
+        assetId
+        assetName
+        localBalance
+        remoteBalance
+        capacity
       }
     }
   }

--- a/src/client/src/graphql/queries/__generated__/getChannels.generated.tsx
+++ b/src/client/src/graphql/queries/__generated__/getChannels.generated.tsx
@@ -68,10 +68,13 @@ export type GetChannelsQuery = {
     } | null;
     asset?: {
       __typename?: 'ChannelAsset';
-      assetId: string;
-      assetName: string;
-      localBalance: string;
-      remoteBalance: string;
+      asset_id: string;
+      asset_name: string;
+      asset_type: string;
+      asset_precision: number;
+      group_key?: string | null;
+      local_balance: string;
+      remote_balance: string;
       capacity: string;
     } | null;
   }>;
@@ -150,10 +153,13 @@ export const GetChannelsDocument = gql`
         }
       }
       asset {
-        assetId
-        assetName
-        localBalance
-        remoteBalance
+        asset_id
+        asset_name
+        asset_type
+        asset_precision
+        group_key
+        local_balance
+        remote_balance
         capacity
       }
     }

--- a/src/client/src/graphql/queries/__generated__/getPeerChannels.generated.tsx
+++ b/src/client/src/graphql/queries/__generated__/getPeerChannels.generated.tsx
@@ -21,10 +21,10 @@ export type GetPeerChannelsQuery = {
     transaction_vout: number;
     asset?: {
       __typename?: 'ChannelAsset';
-      assetId: string;
-      groupKey?: string | null;
-      localBalance: string;
-      remoteBalance: string;
+      asset_id: string;
+      group_key?: string | null;
+      local_balance: string;
+      remote_balance: string;
       capacity: string;
     } | null;
   }>;
@@ -42,10 +42,10 @@ export const GetPeerChannelsDocument = gql`
       transaction_id
       transaction_vout
       asset {
-        assetId
-        groupKey
-        localBalance
-        remoteBalance
+        asset_id
+        group_key
+        local_balance
+        remote_balance
         capacity
       }
     }

--- a/src/client/src/graphql/queries/__generated__/getPendingChannels.generated.tsx
+++ b/src/client/src/graphql/queries/__generated__/getPendingChannels.generated.tsx
@@ -34,10 +34,10 @@ export type GetPendingChannelsQuery = {
     };
     asset?: {
       __typename?: 'ChannelAsset';
-      assetId: string;
-      groupKey?: string | null;
-      localBalance: string;
-      remoteBalance: string;
+      asset_id: string;
+      group_key?: string | null;
+      local_balance: string;
+      remote_balance: string;
       capacity: string;
     } | null;
   }>;
@@ -69,10 +69,10 @@ export const GetPendingChannelsDocument = gql`
         }
       }
       asset {
-        assetId
-        groupKey
-        localBalance
-        remoteBalance
+        asset_id
+        group_key
+        local_balance
+        remote_balance
         capacity
       }
     }

--- a/src/client/src/graphql/queries/__generated__/getTapInfo.generated.tsx
+++ b/src/client/src/graphql/queries/__generated__/getTapInfo.generated.tsx
@@ -3,9 +3,7 @@ import * as Types from '../../types';
 import { gql } from '@apollo/client';
 import * as Apollo from '@apollo/client';
 const defaultOptions = {} as const;
-export type GetTapInfoQueryVariables = Types.Exact<{
-  [key: string]: never;
-}>;
+export type GetTapInfoQueryVariables = Types.Exact<{ [key: string]: never }>;
 
 export type GetTapInfoQuery = {
   __typename?: 'Query';
@@ -93,10 +91,7 @@ export function useGetTapInfoSuspenseQuery(
 export function useGetTapInfoSuspenseQuery(
   baseOptions?:
     | Apollo.SkipToken
-    | Apollo.SuspenseQueryHookOptions<
-        GetTapInfoQuery,
-        GetTapInfoQueryVariables
-      >
+    | Apollo.SuspenseQueryHookOptions<GetTapInfoQuery, GetTapInfoQueryVariables>
 ): Apollo.UseSuspenseQueryResult<
   GetTapInfoQuery | undefined,
   GetTapInfoQueryVariables
@@ -104,10 +99,7 @@ export function useGetTapInfoSuspenseQuery(
 export function useGetTapInfoSuspenseQuery(
   baseOptions?:
     | Apollo.SkipToken
-    | Apollo.SuspenseQueryHookOptions<
-        GetTapInfoQuery,
-        GetTapInfoQueryVariables
-      >
+    | Apollo.SuspenseQueryHookOptions<GetTapInfoQuery, GetTapInfoQueryVariables>
 ) {
   const options =
     baseOptions === Apollo.skipToken

--- a/src/client/src/graphql/queries/getChannels.ts
+++ b/src/client/src/graphql/queries/getChannels.ts
@@ -56,10 +56,13 @@ export const GET_CHANNELS = gql`
         }
       }
       asset {
-        assetId
-        assetName
-        localBalance
-        remoteBalance
+        asset_id
+        asset_name
+        asset_type
+        asset_precision
+        group_key
+        local_balance
+        remote_balance
         capacity
       }
     }

--- a/src/client/src/graphql/queries/getChannels.ts
+++ b/src/client/src/graphql/queries/getChannels.ts
@@ -55,6 +55,13 @@ export const GET_CHANNELS = gql`
           min_htlc_mtokens
         }
       }
+      asset {
+        assetId
+        assetName
+        localBalance
+        remoteBalance
+        capacity
+      }
     }
   }
 `;

--- a/src/client/src/graphql/queries/getPeerChannels.ts
+++ b/src/client/src/graphql/queries/getPeerChannels.ts
@@ -12,10 +12,10 @@ export const GET_PEER_CHANNELS = gql`
       transaction_id
       transaction_vout
       asset {
-        assetId
-        groupKey
-        localBalance
-        remoteBalance
+        asset_id
+        group_key
+        local_balance
+        remote_balance
         capacity
       }
     }

--- a/src/client/src/graphql/queries/getPendingChannels.ts
+++ b/src/client/src/graphql/queries/getPendingChannels.ts
@@ -26,10 +26,10 @@ export const GET_PENDING_CHANNELS = gql`
         }
       }
       asset {
-        assetId
-        groupKey
-        localBalance
-        remoteBalance
+        asset_id
+        group_key
+        local_balance
+        remote_balance
         capacity
       }
     }

--- a/src/client/src/graphql/types.ts
+++ b/src/client/src/graphql/types.ts
@@ -213,6 +213,7 @@ export type Channel = {
 export type ChannelAsset = {
   __typename?: 'ChannelAsset';
   assetId: Scalars['String']['output'];
+  assetName: Scalars['String']['output'];
   capacity: Scalars['String']['output'];
   groupKey?: Maybe<Scalars['String']['output']>;
   localBalance: Scalars['String']['output'];

--- a/src/client/src/graphql/types.ts
+++ b/src/client/src/graphql/types.ts
@@ -212,12 +212,14 @@ export type Channel = {
 
 export type ChannelAsset = {
   __typename?: 'ChannelAsset';
-  assetId: Scalars['String']['output'];
-  assetName: Scalars['String']['output'];
+  asset_id: Scalars['String']['output'];
+  asset_name: Scalars['String']['output'];
+  asset_type: Scalars['String']['output'];
+  asset_precision: Scalars['Float']['output'];
   capacity: Scalars['String']['output'];
-  groupKey?: Maybe<Scalars['String']['output']>;
-  localBalance: Scalars['String']['output'];
-  remoteBalance: Scalars['String']['output'];
+  group_key?: Maybe<Scalars['String']['output']>;
+  local_balance: Scalars['String']['output'];
+  remote_balance: Scalars['String']['output'];
 };
 
 export type ChannelInfo = {
@@ -1348,6 +1350,18 @@ export type TapBalances = {
   balances: Array<TapAssetBalanceEntry>;
 };
 
+export type TapDaemonInfo = {
+  __typename?: 'TapDaemonInfo';
+  block_hash: Scalars['String']['output'];
+  block_height: Scalars['Int']['output'];
+  lnd_identity_pubkey: Scalars['String']['output'];
+  lnd_version: Scalars['String']['output'];
+  network: Scalars['String']['output'];
+  node_alias: Scalars['String']['output'];
+  sync_to_chain: Scalars['Boolean']['output'];
+  version: Scalars['String']['output'];
+};
+
 export type TapFederationServer = {
   __typename?: 'TapFederationServer';
   host: Scalars['String']['output'];
@@ -1581,6 +1595,7 @@ export type TaprootAssetsQueries = {
   get_assets: TapAssetList;
   get_balances: TapBalances;
   get_federation_servers: TapFederationServerList;
+  get_info: TapDaemonInfo;
   get_transfers: TapTransferList;
   get_universe_assets: TapUniverseAssetList;
   get_universe_info: TapUniverseInfo;

--- a/src/client/src/utils/color.ts
+++ b/src/client/src/utils/color.ts
@@ -9,5 +9,5 @@ function stringToHue(input: string): number {
 
 export function colorFromString(input: string): string {
   const hue = stringToHue(input);
-  return `hsl(${hue}, 70%, 55%)`;
+  return `hsla(${hue}, 70%, 55%, 0.8)`;
 }

--- a/src/client/src/utils/color.ts
+++ b/src/client/src/utils/color.ts
@@ -1,0 +1,13 @@
+// djb2a hash → hue angle, following the spirit of XEP-0392
+function stringToHue(input: string): number {
+  let hash = 5381;
+  for (let i = 0; i < input.length; i++) {
+    hash = (((hash << 5) + hash) ^ input.charCodeAt(i)) >>> 0;
+  }
+  return hash % 360;
+}
+
+export function colorFromString(input: string): string {
+  const hue = stringToHue(input);
+  return `hsl(${hue}, 70%, 55%)`;
+}

--- a/src/client/src/views/assets/TradeSheet.tsx
+++ b/src/client/src/views/assets/TradeSheet.tsx
@@ -944,18 +944,26 @@ export const TradeSheet: FC<TradeSheetProps> = ({
                 readyToTrade ? handleReviewTrade : () => setStep('confirm')
               }
               disabled={
+                quoteLoading ||
                 !isValid ||
                 (!readyToTrade && !needsOnlyOutboundBtc && !offer.magmaOfferId)
               }
               className="w-full"
             >
-              {readyToTrade
-                ? 'Review Trade'
-                : needsOnlyOutboundBtc
-                  ? 'Review Channel'
-                  : !offer.magmaOfferId
-                    ? 'No offer available for setup'
-                    : 'Review Setup'}
+              {readyToTrade && quoteLoading ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  Getting quote...
+                </>
+              ) : readyToTrade ? (
+                'Review Trade'
+              ) : needsOnlyOutboundBtc ? (
+                'Review Channel'
+              ) : !offer.magmaOfferId ? (
+                'No offer available for setup'
+              ) : (
+                'Review Setup'
+              )}
             </Button>
           )}
           {step === 'confirm' && (

--- a/src/client/src/views/assets/TradeSheet.tsx
+++ b/src/client/src/views/assets/TradeSheet.tsx
@@ -232,13 +232,13 @@ export const TradeSheet: FC<TradeSheetProps> = ({
     });
 
   const matchAsset = (asset: {
-    groupKey?: string | null;
-    assetId: string;
+    group_key?: string | null;
+    asset_id: string;
   }): boolean =>
     tapdGroupKey
-      ? asset.groupKey === tapdGroupKey
+      ? asset.group_key === tapdGroupKey
       : tapdAssetId
-        ? asset.assetId === tapdAssetId
+        ? asset.asset_id === tapdAssetId
         : false;
 
   // Reset prefill flag when the sheet closes.
@@ -257,7 +257,7 @@ export const TradeSheet: FC<TradeSheetProps> = ({
     // Sum inbound from open asset channels
     const openRemote = (channelsData?.getChannels || [])
       .filter(ch => ch.asset && matchAsset(ch.asset))
-      .reduce((sum, ch) => sum + BigInt(ch.asset?.remoteBalance || '0'), 0n);
+      .reduce((sum, ch) => sum + BigInt(ch.asset?.remote_balance || '0'), 0n);
 
     // Sum capacity from pending asset channels
     const pendingCap = (pendingData?.getPendingChannels || [])
@@ -320,11 +320,11 @@ export const TradeSheet: FC<TradeSheetProps> = ({
     0
   );
   const totalAssetLocal = assetChannels.reduce(
-    (sum, ch) => sum + BigInt(ch.asset?.localBalance || '0'),
+    (sum, ch) => sum + BigInt(ch.asset?.local_balance || '0'),
     0n
   );
   const totalAssetRemote = assetChannels.reduce(
-    (sum, ch) => sum + BigInt(ch.asset?.remoteBalance || '0'),
+    (sum, ch) => sum + BigInt(ch.asset?.remote_balance || '0'),
     0n
   );
   const totalBtcRemote = btcOnlyChannels.reduce(
@@ -644,11 +644,11 @@ export const TradeSheet: FC<TradeSheetProps> = ({
                       txId={ch.transaction_id}
                       capacity={`${atomicToDisplay(ch.asset!.capacity, assetPrecision)} ${assetSymbol}`}
                       local={atomicToDisplay(
-                        ch.asset!.localBalance,
+                        ch.asset!.local_balance,
                         assetPrecision
                       )}
                       remote={atomicToDisplay(
-                        ch.asset!.remoteBalance,
+                        ch.asset!.remote_balance,
                         assetPrecision
                       )}
                     />
@@ -669,11 +669,11 @@ export const TradeSheet: FC<TradeSheetProps> = ({
                       channelId={ch.id}
                       capacity={`${atomicToDisplay(ch.asset!.capacity, assetPrecision)} ${assetSymbol}`}
                       local={atomicToDisplay(
-                        ch.asset!.localBalance,
+                        ch.asset!.local_balance,
                         assetPrecision
                       )}
                       remote={atomicToDisplay(
-                        ch.asset!.remoteBalance,
+                        ch.asset!.remote_balance,
                         assetPrecision
                       )}
                       isActive={ch.is_active}

--- a/src/client/src/views/assets/TradingOffers.tsx
+++ b/src/client/src/views/assets/TradingOffers.tsx
@@ -211,9 +211,9 @@ export const TradingOffers: FC = () => {
       const s = ensure(ch.partner_public_key);
       if (ch.asset) {
         const match = selectedTapdGroupKey
-          ? ch.asset.groupKey === selectedTapdGroupKey
+          ? ch.asset.group_key === selectedTapdGroupKey
           : selectedTapdAssetId
-            ? ch.asset.assetId === selectedTapdAssetId
+            ? ch.asset.asset_id === selectedTapdAssetId
             : false;
         if (match && s.asset === 'none') {
           s.asset = 'pending';

--- a/src/client/src/views/channels/channels/ChannelTable.tsx
+++ b/src/client/src/views/channels/channels/ChannelTable.tsx
@@ -2,7 +2,6 @@ import { useCallback, useMemo, useState } from 'react';
 import { ArrowDown, ArrowUp, Check, Circle, Edit, X } from 'lucide-react';
 import toast from 'react-hot-toast';
 import { BalanceBars } from '../../../components/balance';
-import { ProgressBar } from '../../../components/generic/CardGeneric';
 import {
   getChannelLink,
   getNodeLink,
@@ -27,23 +26,12 @@ import { ChannelDetails } from './ChannelDetails';
 import { defaultHiddenColumns } from './helpers';
 import { VisibilityState } from '@tanstack/react-table';
 
-const AssetLabel = ({
-  asset,
-}: {
-  asset: { assetName: string; assetId: string };
-}) => (
-  <span className="text-gray-500">
-    {asset.assetName || asset.assetId.slice(0, 8)}
-  </span>
-);
-
 const getBar = (top: number, bottom: number) => {
   const percent = (top / bottom) * 100;
   return Math.min(percent, 100);
 };
 
-const BTC_COLOR = '#f7931a';
-const REMOTE_COLOR = '#9ca3af';
+const REMOTE_COLOR = 'rgba(209, 213, 219, 0.6)';
 
 export const ChannelTable = () => {
   const chartColors = useChartColors();
@@ -71,6 +59,27 @@ export const ChannelTable = () => {
     },
     []
   );
+
+  const uniqueAssets = useMemo(() => {
+    const channelData = data?.getChannels || [];
+    const map = new Map<
+      string,
+      { asset_id: string; asset_name: string; group_key?: string }
+    >();
+    for (const c of channelData) {
+      if (c.asset) {
+        const key = c.asset.group_key || c.asset.asset_id;
+        if (!map.has(key)) {
+          map.set(key, {
+            asset_id: c.asset.asset_id,
+            asset_name: c.asset.asset_name,
+            group_key: c.asset.group_key ?? undefined,
+          });
+        }
+      }
+    }
+    return map;
+  }, [data]);
 
   const tableData = useMemo(() => {
     const channelData = data?.getChannels || [];
@@ -176,34 +185,49 @@ export const ChannelTable = () => {
         ),
       };
 
-      const asset = c.asset;
-      const localBal = asset ? Number(asset.localBalance) : c.local_balance;
-      const remoteBal = asset ? Number(asset.remoteBalance) : c.remote_balance;
+      // Build dynamic asset fields for each unique asset
+      const assetFields: Record<string, any> = {};
+      for (const [key] of uniqueAssets) {
+        const channelAssetKey = c.asset
+          ? c.asset.group_key || c.asset.asset_id
+          : null;
+        const match = channelAssetKey === key;
+        const prefix = `asset_${key}`;
 
-      const assetKey = asset?.groupKey || asset?.assetId || '';
-      const assetColor = asset ? colorFromString(assetKey) : undefined;
+        assetFields[`${prefix}_capacity`] = match ? c.asset!.capacity : null;
+        assetFields[`${prefix}_local`] = match
+          ? Number(c.asset!.local_balance)
+          : null;
+        assetFields[`${prefix}_remote`] = match
+          ? Number(c.asset!.remote_balance)
+          : null;
+        assetFields[`${prefix}_balancePercent`] = match
+          ? getPercent(
+              Number(c.asset!.local_balance),
+              Number(c.asset!.remote_balance)
+            )
+          : 0;
 
-      const assetBar = asset ? (
-        <div className="mt-1">
-          <div className="text-xs mb-0.5 text-center">
-            <AssetLabel asset={asset} />
+        const assetColor = colorFromString(key);
+        assetFields[`${prefix}_balanceBar`] = match ? (
+          <div className="min-w-[180px]">
+            <BalanceBars
+              local={getPercent(
+                Number(c.asset!.local_balance),
+                Number(c.asset!.remote_balance)
+              )}
+              remote={getPercent(
+                Number(c.asset!.remote_balance),
+                Number(c.asset!.local_balance)
+              )}
+              formatLocal={formatNumber(c.asset!.local_balance)}
+              formatRemote={formatNumber(c.asset!.remote_balance)}
+              localColor={assetColor}
+              remoteColor={REMOTE_COLOR}
+            />
           </div>
-          <BalanceBars
-            local={getPercent(
-              Number(asset.localBalance),
-              Number(asset.remoteBalance)
-            )}
-            remote={getPercent(
-              Number(asset.remoteBalance),
-              Number(asset.localBalance)
-            )}
-            formatLocal={formatNumber(asset.localBalance)}
-            formatRemote={formatNumber(asset.remoteBalance)}
-            localColor={assetColor}
-            remoteColor={REMOTE_COLOR}
-          />
-        </div>
-      ) : null;
+        ) : null;
+      }
 
       return {
         ...c,
@@ -212,6 +236,7 @@ export const ChannelTable = () => {
         ...pending,
         ...partnerInfo,
         ...actions,
+        ...assetFields,
         alias: c.partner_node_info.node?.alias || 'Unknown',
         undercaseAlias: (
           c.partner_node_info.node?.alias || 'Unknown'
@@ -226,118 +251,52 @@ export const ChannelTable = () => {
           144 *
           30
         ).toFixed(2),
-        balancePercent: getPercent(localBal, remoteBal),
-        remoteBalancePercent: getPercent(remoteBal, localBal),
-        balancePercentText: `${getPercent(localBal, remoteBal)}%`,
+        balancePercent: getPercent(c.local_balance, c.remote_balance),
+        balancePercentText: `${getPercent(c.local_balance, c.remote_balance)}%`,
         proportionalBars: (
           <div className="min-w-[180px]">
             <BalanceBars
               local={getBar(c.local_balance, maxBalance)}
               remote={getBar(c.remote_balance, maxBalance)}
               formatLocal={
-                <Price amount={c.local_balance} breakNumber={true} />
+                <Price
+                  amount={c.local_balance}
+                  breakNumber={true}
+                  noUnit={true}
+                />
               }
               formatRemote={
-                <Price amount={c.remote_balance} breakNumber={true} />
+                <Price
+                  amount={c.remote_balance}
+                  breakNumber={true}
+                  noUnit={true}
+                />
               }
-              localColor={BTC_COLOR}
-              remoteColor={REMOTE_COLOR}
             />
-            {assetBar}
           </div>
         ),
-        balanceBarsLocal: (() => {
-          const btcPct = getPercent(c.local_balance, c.remote_balance);
-          const assetPct = asset
-            ? getPercent(
-                Number(asset.localBalance),
-                Number(asset.remoteBalance)
-              )
-            : 0;
-          return (
-            <div className="min-w-[80px]">
-              <div className="w-full flex">
-                <ProgressBar
-                  barHeight={10}
-                  order={1}
-                  percent={btcPct}
-                  style={{ backgroundColor: BTC_COLOR }}
+        balanceBars: (
+          <div className="min-w-[180px]">
+            <BalanceBars
+              local={getPercent(c.local_balance, c.remote_balance)}
+              remote={getPercent(c.remote_balance, c.local_balance)}
+              formatLocal={
+                <Price
+                  amount={c.local_balance}
+                  breakNumber={true}
+                  noUnit={true}
                 />
-                <ProgressBar barHeight={10} order={4} percent={100 - btcPct} />
-              </div>
-              <div>
-                <Price amount={c.local_balance} breakNumber={true} />
-              </div>
-              {asset && (
-                <>
-                  <div className="w-full flex mt-1">
-                    <ProgressBar
-                      barHeight={10}
-                      order={1}
-                      percent={assetPct}
-                      style={{ backgroundColor: assetColor }}
-                    />
-                    <ProgressBar
-                      barHeight={10}
-                      order={4}
-                      percent={100 - assetPct}
-                    />
-                  </div>
-                  <div className="text-xs">
-                    {formatNumber(asset.localBalance)}{' '}
-                    <AssetLabel asset={asset} />
-                  </div>
-                </>
-              )}
-            </div>
-          );
-        })(),
-        balanceBarsRemote: (() => {
-          const btcPct = getPercent(c.remote_balance, c.local_balance);
-          const assetPct = asset
-            ? getPercent(
-                Number(asset.remoteBalance),
-                Number(asset.localBalance)
-              )
-            : 0;
-          return (
-            <div className="min-w-[80px]">
-              <div className="w-full flex">
-                <ProgressBar
-                  barHeight={10}
-                  order={2}
-                  percent={btcPct}
-                  style={{ backgroundColor: REMOTE_COLOR }}
+              }
+              formatRemote={
+                <Price
+                  amount={c.remote_balance}
+                  breakNumber={true}
+                  noUnit={true}
                 />
-                <ProgressBar barHeight={10} order={4} percent={100 - btcPct} />
-              </div>
-              <div>
-                <Price amount={c.remote_balance} breakNumber={true} />
-              </div>
-              {asset && (
-                <>
-                  <div className="w-full flex mt-1">
-                    <ProgressBar
-                      barHeight={10}
-                      order={2}
-                      percent={assetPct}
-                      style={{ backgroundColor: REMOTE_COLOR }}
-                    />
-                    <ProgressBar
-                      barHeight={10}
-                      order={4}
-                      percent={100 - assetPct}
-                    />
-                  </div>
-                  <div className="text-xs">
-                    {formatNumber(asset.remoteBalance)}{' '}
-                    <AssetLabel asset={asset} />
-                  </div>
-                </>
-              )}
-            </div>
-          );
-        })(),
+              }
+            />
+          </div>
+        ),
         activityBars: (
           <div className="min-w-[180px]">
             <BalanceBars
@@ -354,7 +313,7 @@ export const ChannelTable = () => {
         ),
       };
     });
-  }, [data, chartColors]);
+  }, [data, chartColors, uniqueAssets]);
 
   const columns = useMemo(
     () => [
@@ -426,21 +385,11 @@ export const ChannelTable = () => {
           {
             header: 'Capacity',
             accessorKey: 'capacity',
-            cell: ({ row }: any) => {
-              const asset = row.original.asset;
-              return (
-                <div className="whitespace-nowrap">
-                  <div>
-                    <Price amount={row.original.capacity} />
-                  </div>
-                  {asset && (
-                    <div className="text-xs">
-                      {asset.capacity} <AssetLabel asset={asset} />
-                    </div>
-                  )}
-                </div>
-              );
-            },
+            cell: ({ row }: any) => (
+              <div className="whitespace-nowrap">
+                <Price amount={row.original.capacity} />
+              </div>
+            ),
           },
           { header: 'Block Age', accessorKey: 'channel_age' },
           {
@@ -464,42 +413,20 @@ export const ChannelTable = () => {
           {
             header: 'Local',
             accessorKey: 'local_balance',
-            cell: ({ row }: any) => {
-              const asset = row.original.asset;
-              return (
-                <div className="whitespace-nowrap">
-                  <div>
-                    <Price amount={row.original.local_balance} />
-                  </div>
-                  {asset && (
-                    <div className="text-xs">
-                      {formatNumber(asset.localBalance)}{' '}
-                      <AssetLabel asset={asset} />
-                    </div>
-                  )}
-                </div>
-              );
-            },
+            cell: ({ row }: any) => (
+              <div className="whitespace-nowrap">
+                <Price amount={row.original.local_balance} />
+              </div>
+            ),
           },
           {
             header: 'Remote',
             accessorKey: 'remote_balance',
-            cell: ({ row }: any) => {
-              const asset = row.original.asset;
-              return (
-                <div className="whitespace-nowrap">
-                  <div>
-                    <Price amount={row.original.remote_balance} />
-                  </div>
-                  {asset && (
-                    <div className="text-xs">
-                      {formatNumber(asset.remoteBalance)}{' '}
-                      <AssetLabel asset={asset} />
-                    </div>
-                  )}
-                </div>
-              );
-            },
+            cell: ({ row }: any) => (
+              <div className="whitespace-nowrap">
+                <Price amount={row.original.remote_balance} />
+              </div>
+            ),
           },
           {
             header: 'Percent',
@@ -617,20 +544,9 @@ export const ChannelTable = () => {
         columns: [
           {
             header: 'Balance',
-            columns: [
-              {
-                header: 'Local',
-                accessorKey: 'balanceBarsLocal',
-                sortingFn: numberStringSorting('balancePercent'),
-                cell: ({ cell }: any) => cell.renderValue(),
-              },
-              {
-                header: 'Remote',
-                accessorKey: 'balanceBarsRemote',
-                sortingFn: numberStringSorting('remoteBalancePercent'),
-                cell: ({ cell }: any) => cell.renderValue(),
-              },
-            ],
+            accessorKey: 'balanceBars',
+            sortingFn: numberStringSorting('balancePercent'),
+            cell: ({ cell }: any) => cell.renderValue(),
           },
           {
             header: 'Proportional',
@@ -646,8 +562,65 @@ export const ChannelTable = () => {
           },
         ],
       },
+      ...Array.from(uniqueAssets.entries()).map(([key, assetInfo]) => {
+        const prefix = `asset_${key}`;
+        const name = assetInfo.asset_name || assetInfo.asset_id.slice(0, 8);
+        const label = `Asset (${name})`;
+
+        return {
+          id: prefix,
+          header: label,
+          columns: [
+            {
+              header: 'Capacity',
+              accessorKey: `${prefix}_capacity`,
+              cell: ({ cell }: any) => {
+                const val = cell.getValue();
+                return val != null ? (
+                  <div className="whitespace-nowrap">{formatNumber(val)}</div>
+                ) : (
+                  <span className="text-muted-foreground">-</span>
+                );
+              },
+            },
+            {
+              header: 'Local',
+              accessorKey: `${prefix}_local`,
+              cell: ({ cell }: any) => {
+                const val = cell.getValue();
+                return val != null ? (
+                  <div className="whitespace-nowrap">{formatNumber(val)}</div>
+                ) : (
+                  <span className="text-muted-foreground">-</span>
+                );
+              },
+            },
+            {
+              header: 'Remote',
+              accessorKey: `${prefix}_remote`,
+              cell: ({ cell }: any) => {
+                const val = cell.getValue();
+                return val != null ? (
+                  <div className="whitespace-nowrap">{formatNumber(val)}</div>
+                ) : (
+                  <span className="text-muted-foreground">-</span>
+                );
+              },
+            },
+            {
+              header: 'Balance',
+              accessorKey: `${prefix}_balanceBar`,
+              sortingFn: numberStringSorting(`${prefix}_balancePercent`),
+              cell: ({ cell }: any) =>
+                cell.renderValue() || (
+                  <span className="text-muted-foreground">-</span>
+                ),
+            },
+          ],
+        };
+      }),
     ],
-    [numberStringSorting]
+    [numberStringSorting, uniqueAssets]
   );
 
   const handleToggle = (hide: boolean, id: string) => {
@@ -705,7 +678,7 @@ export const ChannelTable = () => {
         data={tableData}
         withGlobalSort={true}
         withSorting={true}
-        initSorting={[{ id: 'balanceBarsLocal', desc: false }]}
+        initSorting={[{ id: 'balanceBars', desc: false }]}
         toggleConfiguration={handleToggle}
         defaultHiddenColumns={hiddenColumnState}
         filterPlaceholder="channels"

--- a/src/client/src/views/channels/channels/ChannelTable.tsx
+++ b/src/client/src/views/channels/channels/ChannelTable.tsx
@@ -415,11 +415,24 @@ export const ChannelTable = () => {
           {
             header: 'Capacity',
             accessorKey: 'capacity',
-            cell: ({ row }: any) => (
-              <div className="whitespace-nowrap">
-                <Price amount={row.original.capacity} />
-              </div>
-            ),
+            cell: ({ row }: any) => {
+              const asset = row.original.asset;
+              return (
+                <div className="whitespace-nowrap">
+                  <div>
+                    <Price amount={row.original.capacity} />
+                  </div>
+                  {asset && (
+                    <div className="text-xs">
+                      {asset.capacity}{' '}
+                      <span className="text-gray-500">
+                        {asset.assetName || asset.assetId.slice(0, 8)}
+                      </span>
+                    </div>
+                  )}
+                </div>
+              );
+            },
           },
           { header: 'Block Age', accessorKey: 'channel_age' },
           {

--- a/src/client/src/views/channels/channels/ChannelTable.tsx
+++ b/src/client/src/views/channels/channels/ChannelTable.tsx
@@ -16,6 +16,7 @@ import { useLocalStorage } from '../../../hooks/UseLocalStorage';
 import { useChartColors } from '../../../lib/chart-colors';
 import { getErrorContent } from '../../../utils/error';
 import { blockToTime, formatSeconds, getPercent } from '../../../utils/helpers';
+import { colorFromString } from '../../../utils/color';
 import { ChannelDetails } from './ChannelDetails';
 import { defaultHiddenColumns } from './helpers';
 import { VisibilityState } from '@tanstack/react-table';
@@ -55,13 +56,10 @@ export const ChannelTable = () => {
   const tableData = useMemo(() => {
     const channelData = data?.getChannels || [];
 
-    const balanceArray = channelData.reduce((p, c) => {
-      const lb = c.asset ? Number(c.asset.localBalance) : c.local_balance || 0;
-      const rb = c.asset
-        ? Number(c.asset.remoteBalance)
-        : c.remote_balance || 0;
-      return [...p, rb, lb];
-    }, [] as number[]);
+    const balanceArray = channelData.reduce(
+      (p, c) => [...p, c.remote_balance || 0, c.local_balance || 0],
+      [] as number[]
+    );
 
     const maxBalance = Math.max(...balanceArray);
 
@@ -162,12 +160,36 @@ export const ChannelTable = () => {
       const asset = c.asset;
       const localBal = asset ? Number(asset.localBalance) : c.local_balance;
       const remoteBal = asset ? Number(asset.remoteBalance) : c.remote_balance;
-      const formatBal = (btcAmount: number, assetAmount: number) =>
-        asset ? (
-          <span>{assetAmount}</span>
-        ) : (
-          <Price amount={btcAmount} breakNumber={true} noUnit={true} />
-        );
+
+      const assetKey = asset?.groupKey || asset?.assetId || '';
+      const assetLocalColor = asset
+        ? colorFromString(assetKey + 'local')
+        : undefined;
+      const assetRemoteColor = asset
+        ? colorFromString(assetKey + 'remote')
+        : undefined;
+
+      const assetBar = asset ? (
+        <div className="mt-1">
+          <div className="text-xs text-gray-500 mb-0.5 text-center">
+            {asset.assetName || asset.assetId.slice(0, 8)}
+          </div>
+          <BalanceBars
+            local={getPercent(
+              Number(asset.localBalance),
+              Number(asset.remoteBalance)
+            )}
+            remote={getPercent(
+              Number(asset.remoteBalance),
+              Number(asset.localBalance)
+            )}
+            formatLocal={String(asset.localBalance)}
+            formatRemote={String(asset.remoteBalance)}
+            localColor={assetLocalColor}
+            remoteColor={assetRemoteColor}
+          />
+        </div>
+      ) : null;
 
       return {
         ...c,
@@ -176,6 +198,8 @@ export const ChannelTable = () => {
         ...pending,
         ...partnerInfo,
         ...actions,
+        assetLocalColor,
+        assetRemoteColor,
         alias: c.partner_node_info.node?.alias || 'Unknown',
         undercaseAlias: (
           c.partner_node_info.node?.alias || 'Unknown'
@@ -195,21 +219,47 @@ export const ChannelTable = () => {
         proportionalBars: (
           <div className="min-w-[180px]">
             <BalanceBars
-              local={getBar(localBal, maxBalance)}
-              remote={getBar(remoteBal, maxBalance)}
-              formatLocal={formatBal(c.local_balance, localBal)}
-              formatRemote={formatBal(c.remote_balance, remoteBal)}
+              local={getBar(c.local_balance, maxBalance)}
+              remote={getBar(c.remote_balance, maxBalance)}
+              formatLocal={
+                <Price
+                  amount={c.local_balance}
+                  breakNumber={true}
+                  noUnit={true}
+                />
+              }
+              formatRemote={
+                <Price
+                  amount={c.remote_balance}
+                  breakNumber={true}
+                  noUnit={true}
+                />
+              }
             />
+            {assetBar}
           </div>
         ),
         balanceBars: (
           <div className="min-w-[180px]">
             <BalanceBars
-              local={getPercent(localBal, remoteBal)}
-              remote={getPercent(remoteBal, localBal)}
-              formatLocal={formatBal(c.local_balance, localBal)}
-              formatRemote={formatBal(c.remote_balance, remoteBal)}
+              local={getPercent(c.local_balance, c.remote_balance)}
+              remote={getPercent(c.remote_balance, c.local_balance)}
+              formatLocal={
+                <Price
+                  amount={c.local_balance}
+                  breakNumber={true}
+                  noUnit={true}
+                />
+              }
+              formatRemote={
+                <Price
+                  amount={c.remote_balance}
+                  breakNumber={true}
+                  noUnit={true}
+                />
+              }
             />
+            {assetBar}
           </div>
         ),
         activityBars: (
@@ -332,11 +382,14 @@ export const ChannelTable = () => {
               const asset = row.original.asset;
               return (
                 <div className="whitespace-nowrap">
-                  <div>
+                  <div style={{ color: '#1890ff' }}>
                     <Price amount={row.original.local_balance} />
                   </div>
                   {asset && (
-                    <div className="text-xs">
+                    <div
+                      className="text-xs"
+                      style={{ color: row.original.assetLocalColor }}
+                    >
                       {asset.localBalance}{' '}
                       <span className="text-gray-500">
                         {asset.assetName || asset.assetId.slice(0, 8)}
@@ -354,11 +407,14 @@ export const ChannelTable = () => {
               const asset = row.original.asset;
               return (
                 <div className="whitespace-nowrap">
-                  <div>
+                  <div style={{ color: '#a0d911' }}>
                     <Price amount={row.original.remote_balance} />
                   </div>
                   {asset && (
-                    <div className="text-xs">
+                    <div
+                      className="text-xs"
+                      style={{ color: row.original.assetRemoteColor }}
+                    >
                       {asset.remoteBalance}{' '}
                       <span className="text-gray-500">
                         {asset.assetName || asset.assetId.slice(0, 8)}

--- a/src/client/src/views/channels/channels/ChannelTable.tsx
+++ b/src/client/src/views/channels/channels/ChannelTable.tsx
@@ -2,6 +2,7 @@ import { useCallback, useMemo, useState } from 'react';
 import { ArrowDown, ArrowUp, Check, Circle, Edit, X } from 'lucide-react';
 import toast from 'react-hot-toast';
 import { BalanceBars } from '../../../components/balance';
+import { ProgressBar } from '../../../components/generic/CardGeneric';
 import {
   getChannelLink,
   getNodeLink,
@@ -25,6 +26,9 @@ const getBar = (top: number, bottom: number) => {
   const percent = (top / bottom) * 100;
   return Math.min(percent, 100);
 };
+
+const BTC_COLOR = '#f7931a';
+const REMOTE_COLOR = '#9ca3af';
 
 export const ChannelTable = () => {
   const chartColors = useChartColors();
@@ -162,12 +166,7 @@ export const ChannelTable = () => {
       const remoteBal = asset ? Number(asset.remoteBalance) : c.remote_balance;
 
       const assetKey = asset?.groupKey || asset?.assetId || '';
-      const assetLocalColor = asset
-        ? colorFromString(assetKey + 'local')
-        : undefined;
-      const assetRemoteColor = asset
-        ? colorFromString(assetKey + 'remote')
-        : undefined;
+      const assetColor = asset ? colorFromString(assetKey) : undefined;
 
       const assetBar = asset ? (
         <div className="mt-1">
@@ -185,8 +184,8 @@ export const ChannelTable = () => {
             )}
             formatLocal={String(asset.localBalance)}
             formatRemote={String(asset.remoteBalance)}
-            localColor={assetLocalColor}
-            remoteColor={assetRemoteColor}
+            localColor={assetColor}
+            remoteColor={REMOTE_COLOR}
           />
         </div>
       ) : null;
@@ -198,8 +197,6 @@ export const ChannelTable = () => {
         ...pending,
         ...partnerInfo,
         ...actions,
-        assetLocalColor,
-        assetRemoteColor,
         alias: c.partner_node_info.node?.alias || 'Unknown',
         undercaseAlias: (
           c.partner_node_info.node?.alias || 'Unknown'
@@ -215,6 +212,7 @@ export const ChannelTable = () => {
           30
         ).toFixed(2),
         balancePercent: getPercent(localBal, remoteBal),
+        remoteBalancePercent: getPercent(remoteBal, localBal),
         balancePercentText: `${getPercent(localBal, remoteBal)}%`,
         proportionalBars: (
           <div className="min-w-[180px]">
@@ -222,46 +220,113 @@ export const ChannelTable = () => {
               local={getBar(c.local_balance, maxBalance)}
               remote={getBar(c.remote_balance, maxBalance)}
               formatLocal={
-                <Price
-                  amount={c.local_balance}
-                  breakNumber={true}
-                  noUnit={true}
-                />
+                <Price amount={c.local_balance} breakNumber={true} />
               }
               formatRemote={
-                <Price
-                  amount={c.remote_balance}
-                  breakNumber={true}
-                  noUnit={true}
-                />
+                <Price amount={c.remote_balance} breakNumber={true} />
               }
+              localColor={BTC_COLOR}
+              remoteColor={REMOTE_COLOR}
             />
             {assetBar}
           </div>
         ),
-        balanceBars: (
-          <div className="min-w-[180px]">
-            <BalanceBars
-              local={getPercent(c.local_balance, c.remote_balance)}
-              remote={getPercent(c.remote_balance, c.local_balance)}
-              formatLocal={
-                <Price
-                  amount={c.local_balance}
-                  breakNumber={true}
-                  noUnit={true}
+        balanceBarsLocal: (() => {
+          const btcPct = getPercent(c.local_balance, c.remote_balance);
+          const assetPct = asset
+            ? getPercent(
+                Number(asset.localBalance),
+                Number(asset.remoteBalance)
+              )
+            : 0;
+          return (
+            <div className="min-w-[80px]">
+              <div className="w-full flex">
+                <ProgressBar
+                  barHeight={10}
+                  order={1}
+                  percent={btcPct}
+                  style={{ backgroundColor: BTC_COLOR }}
                 />
-              }
-              formatRemote={
-                <Price
-                  amount={c.remote_balance}
-                  breakNumber={true}
-                  noUnit={true}
+                <ProgressBar barHeight={10} order={4} percent={100 - btcPct} />
+              </div>
+              <div>
+                <Price amount={c.local_balance} breakNumber={true} />
+              </div>
+              {asset && (
+                <>
+                  <div className="w-full flex mt-1">
+                    <ProgressBar
+                      barHeight={10}
+                      order={1}
+                      percent={assetPct}
+                      style={{ backgroundColor: assetColor }}
+                    />
+                    <ProgressBar
+                      barHeight={10}
+                      order={4}
+                      percent={100 - assetPct}
+                    />
+                  </div>
+                  <div className="text-xs">
+                    {asset.localBalance}{' '}
+                    <span className="text-gray-500">
+                      {asset.assetName || asset.assetId.slice(0, 8)}
+                    </span>
+                  </div>
+                </>
+              )}
+            </div>
+          );
+        })(),
+        balanceBarsRemote: (() => {
+          const btcPct = getPercent(c.remote_balance, c.local_balance);
+          const assetPct = asset
+            ? getPercent(
+                Number(asset.remoteBalance),
+                Number(asset.localBalance)
+              )
+            : 0;
+          return (
+            <div className="min-w-[80px]">
+              <div className="w-full flex">
+                <ProgressBar
+                  barHeight={10}
+                  order={2}
+                  percent={btcPct}
+                  style={{ backgroundColor: REMOTE_COLOR }}
                 />
-              }
-            />
-            {assetBar}
-          </div>
-        ),
+                <ProgressBar barHeight={10} order={4} percent={100 - btcPct} />
+              </div>
+              <div>
+                <Price amount={c.remote_balance} breakNumber={true} />
+              </div>
+              {asset && (
+                <>
+                  <div className="w-full flex mt-1">
+                    <ProgressBar
+                      barHeight={10}
+                      order={2}
+                      percent={assetPct}
+                      style={{ backgroundColor: REMOTE_COLOR }}
+                    />
+                    <ProgressBar
+                      barHeight={10}
+                      order={4}
+                      percent={100 - assetPct}
+                    />
+                  </div>
+                  <div className="text-xs">
+                    {asset.remoteBalance}{' '}
+                    <span className="text-gray-500">
+                      {asset.assetName || asset.assetId.slice(0, 8)}
+                    </span>
+                  </div>
+                </>
+              )}
+            </div>
+          );
+        })(),
         activityBars: (
           <div className="min-w-[180px]">
             <BalanceBars
@@ -382,14 +447,11 @@ export const ChannelTable = () => {
               const asset = row.original.asset;
               return (
                 <div className="whitespace-nowrap">
-                  <div style={{ color: '#1890ff' }}>
+                  <div>
                     <Price amount={row.original.local_balance} />
                   </div>
                   {asset && (
-                    <div
-                      className="text-xs"
-                      style={{ color: row.original.assetLocalColor }}
-                    >
+                    <div className="text-xs">
                       {asset.localBalance}{' '}
                       <span className="text-gray-500">
                         {asset.assetName || asset.assetId.slice(0, 8)}
@@ -407,14 +469,11 @@ export const ChannelTable = () => {
               const asset = row.original.asset;
               return (
                 <div className="whitespace-nowrap">
-                  <div style={{ color: '#a0d911' }}>
+                  <div>
                     <Price amount={row.original.remote_balance} />
                   </div>
                   {asset && (
-                    <div
-                      className="text-xs"
-                      style={{ color: row.original.assetRemoteColor }}
-                    >
+                    <div className="text-xs">
                       {asset.remoteBalance}{' '}
                       <span className="text-gray-500">
                         {asset.assetName || asset.assetId.slice(0, 8)}
@@ -541,9 +600,20 @@ export const ChannelTable = () => {
         columns: [
           {
             header: 'Balance',
-            accessorKey: 'balanceBars',
-            sortingFn: numberStringSorting('balancePercent'),
-            cell: ({ cell }: any) => cell.renderValue(),
+            columns: [
+              {
+                header: 'Local',
+                accessorKey: 'balanceBarsLocal',
+                sortingFn: numberStringSorting('balancePercent'),
+                cell: ({ cell }: any) => cell.renderValue(),
+              },
+              {
+                header: 'Remote',
+                accessorKey: 'balanceBarsRemote',
+                sortingFn: numberStringSorting('remoteBalancePercent'),
+                cell: ({ cell }: any) => cell.renderValue(),
+              },
+            ],
           },
           {
             header: 'Proportional',

--- a/src/client/src/views/channels/channels/ChannelTable.tsx
+++ b/src/client/src/views/channels/channels/ChannelTable.tsx
@@ -55,10 +55,13 @@ export const ChannelTable = () => {
   const tableData = useMemo(() => {
     const channelData = data?.getChannels || [];
 
-    const balanceArray = channelData.reduce(
-      (p, c) => [...p, c.remote_balance || 0, c.local_balance || 0],
-      [] as number[]
-    );
+    const balanceArray = channelData.reduce((p, c) => {
+      const lb = c.asset ? Number(c.asset.localBalance) : c.local_balance || 0;
+      const rb = c.asset
+        ? Number(c.asset.remoteBalance)
+        : c.remote_balance || 0;
+      return [...p, rb, lb];
+    }, [] as number[]);
 
     const maxBalance = Math.max(...balanceArray);
 
@@ -156,6 +159,16 @@ export const ChannelTable = () => {
         ),
       };
 
+      const asset = c.asset;
+      const localBal = asset ? Number(asset.localBalance) : c.local_balance;
+      const remoteBal = asset ? Number(asset.remoteBalance) : c.remote_balance;
+      const formatBal = (btcAmount: number, assetAmount: number) =>
+        asset ? (
+          <span>{assetAmount}</span>
+        ) : (
+          <Price amount={btcAmount} breakNumber={true} noUnit={true} />
+        );
+
       return {
         ...c,
         ...status,
@@ -177,49 +190,25 @@ export const ChannelTable = () => {
           144 *
           30
         ).toFixed(2),
-        balancePercent: getPercent(c.local_balance, c.remote_balance),
-        balancePercentText: `${getPercent(c.local_balance, c.remote_balance)}%`,
+        balancePercent: getPercent(localBal, remoteBal),
+        balancePercentText: `${getPercent(localBal, remoteBal)}%`,
         proportionalBars: (
           <div className="min-w-[180px]">
             <BalanceBars
-              local={getBar(c.local_balance, maxBalance)}
-              remote={getBar(c.remote_balance, maxBalance)}
-              formatLocal={
-                <Price
-                  amount={c.local_balance}
-                  breakNumber={true}
-                  noUnit={true}
-                />
-              }
-              formatRemote={
-                <Price
-                  amount={c.remote_balance}
-                  breakNumber={true}
-                  noUnit={true}
-                />
-              }
+              local={getBar(localBal, maxBalance)}
+              remote={getBar(remoteBal, maxBalance)}
+              formatLocal={formatBal(c.local_balance, localBal)}
+              formatRemote={formatBal(c.remote_balance, remoteBal)}
             />
           </div>
         ),
         balanceBars: (
           <div className="min-w-[180px]">
             <BalanceBars
-              local={getPercent(c.local_balance, c.remote_balance)}
-              remote={getPercent(c.remote_balance, c.local_balance)}
-              formatLocal={
-                <Price
-                  amount={c.local_balance}
-                  breakNumber={true}
-                  noUnit={true}
-                />
-              }
-              formatRemote={
-                <Price
-                  amount={c.remote_balance}
-                  breakNumber={true}
-                  noUnit={true}
-                />
-              }
+              local={getPercent(localBal, remoteBal)}
+              remote={getPercent(remoteBal, localBal)}
+              formatLocal={formatBal(c.local_balance, localBal)}
+              formatRemote={formatBal(c.remote_balance, remoteBal)}
             />
           </div>
         ),
@@ -339,20 +328,46 @@ export const ChannelTable = () => {
           {
             header: 'Local',
             accessorKey: 'local_balance',
-            cell: ({ row }: any) => (
-              <div className="whitespace-nowrap">
-                <Price amount={row.original.local_balance} />
-              </div>
-            ),
+            cell: ({ row }: any) => {
+              const asset = row.original.asset;
+              return (
+                <div className="whitespace-nowrap">
+                  <div>
+                    <Price amount={row.original.local_balance} />
+                  </div>
+                  {asset && (
+                    <div className="text-xs">
+                      {asset.localBalance}{' '}
+                      <span className="text-gray-500">
+                        {asset.assetName || asset.assetId.slice(0, 8)}
+                      </span>
+                    </div>
+                  )}
+                </div>
+              );
+            },
           },
           {
             header: 'Remote',
             accessorKey: 'remote_balance',
-            cell: ({ row }: any) => (
-              <div className="whitespace-nowrap">
-                <Price amount={row.original.remote_balance} />
-              </div>
-            ),
+            cell: ({ row }: any) => {
+              const asset = row.original.asset;
+              return (
+                <div className="whitespace-nowrap">
+                  <div>
+                    <Price amount={row.original.remote_balance} />
+                  </div>
+                  {asset && (
+                    <div className="text-xs">
+                      {asset.remoteBalance}{' '}
+                      <span className="text-gray-500">
+                        {asset.assetName || asset.assetId.slice(0, 8)}
+                      </span>
+                    </div>
+                  )}
+                </div>
+              );
+            },
           },
           {
             header: 'Percent',

--- a/src/client/src/views/channels/channels/ChannelTable.tsx
+++ b/src/client/src/views/channels/channels/ChannelTable.tsx
@@ -16,7 +16,12 @@ import { useGetChannelsQuery } from '../../../graphql/queries/__generated__/getC
 import { useLocalStorage } from '../../../hooks/UseLocalStorage';
 import { useChartColors } from '../../../lib/chart-colors';
 import { getErrorContent } from '../../../utils/error';
-import { blockToTime, formatSeconds, getPercent } from '../../../utils/helpers';
+import {
+  blockToTime,
+  formatNumber,
+  formatSeconds,
+  getPercent,
+} from '../../../utils/helpers';
 import { colorFromString } from '../../../utils/color';
 import { ChannelDetails } from './ChannelDetails';
 import { defaultHiddenColumns } from './helpers';
@@ -182,8 +187,8 @@ export const ChannelTable = () => {
               Number(asset.remoteBalance),
               Number(asset.localBalance)
             )}
-            formatLocal={String(asset.localBalance)}
-            formatRemote={String(asset.remoteBalance)}
+            formatLocal={formatNumber(asset.localBalance)}
+            formatRemote={formatNumber(asset.remoteBalance)}
             localColor={assetColor}
             remoteColor={REMOTE_COLOR}
           />
@@ -269,7 +274,7 @@ export const ChannelTable = () => {
                     />
                   </div>
                   <div className="text-xs">
-                    {asset.localBalance}{' '}
+                    {formatNumber(asset.localBalance)}{' '}
                     <span className="text-gray-500">
                       {asset.assetName || asset.assetId.slice(0, 8)}
                     </span>
@@ -317,7 +322,7 @@ export const ChannelTable = () => {
                     />
                   </div>
                   <div className="text-xs">
-                    {asset.remoteBalance}{' '}
+                    {formatNumber(asset.remoteBalance)}{' '}
                     <span className="text-gray-500">
                       {asset.assetName || asset.assetId.slice(0, 8)}
                     </span>
@@ -465,7 +470,7 @@ export const ChannelTable = () => {
                   </div>
                   {asset && (
                     <div className="text-xs">
-                      {asset.localBalance}{' '}
+                      {formatNumber(asset.localBalance)}{' '}
                       <span className="text-gray-500">
                         {asset.assetName || asset.assetId.slice(0, 8)}
                       </span>
@@ -487,7 +492,7 @@ export const ChannelTable = () => {
                   </div>
                   {asset && (
                     <div className="text-xs">
-                      {asset.remoteBalance}{' '}
+                      {formatNumber(asset.remoteBalance)}{' '}
                       <span className="text-gray-500">
                         {asset.assetName || asset.assetId.slice(0, 8)}
                       </span>

--- a/src/client/src/views/channels/channels/ChannelTable.tsx
+++ b/src/client/src/views/channels/channels/ChannelTable.tsx
@@ -27,6 +27,16 @@ import { ChannelDetails } from './ChannelDetails';
 import { defaultHiddenColumns } from './helpers';
 import { VisibilityState } from '@tanstack/react-table';
 
+const AssetLabel = ({
+  asset,
+}: {
+  asset: { assetName: string; assetId: string };
+}) => (
+  <span className="text-gray-500">
+    {asset.assetName || asset.assetId.slice(0, 8)}
+  </span>
+);
+
 const getBar = (top: number, bottom: number) => {
   const percent = (top / bottom) * 100;
   return Math.min(percent, 100);
@@ -175,8 +185,8 @@ export const ChannelTable = () => {
 
       const assetBar = asset ? (
         <div className="mt-1">
-          <div className="text-xs text-gray-500 mb-0.5 text-center">
-            {asset.assetName || asset.assetId.slice(0, 8)}
+          <div className="text-xs mb-0.5 text-center">
+            <AssetLabel asset={asset} />
           </div>
           <BalanceBars
             local={getPercent(
@@ -275,9 +285,7 @@ export const ChannelTable = () => {
                   </div>
                   <div className="text-xs">
                     {formatNumber(asset.localBalance)}{' '}
-                    <span className="text-gray-500">
-                      {asset.assetName || asset.assetId.slice(0, 8)}
-                    </span>
+                    <AssetLabel asset={asset} />
                   </div>
                 </>
               )}
@@ -323,9 +331,7 @@ export const ChannelTable = () => {
                   </div>
                   <div className="text-xs">
                     {formatNumber(asset.remoteBalance)}{' '}
-                    <span className="text-gray-500">
-                      {asset.assetName || asset.assetId.slice(0, 8)}
-                    </span>
+                    <AssetLabel asset={asset} />
                   </div>
                 </>
               )}
@@ -429,10 +435,7 @@ export const ChannelTable = () => {
                   </div>
                   {asset && (
                     <div className="text-xs">
-                      {asset.capacity}{' '}
-                      <span className="text-gray-500">
-                        {asset.assetName || asset.assetId.slice(0, 8)}
-                      </span>
+                      {asset.capacity} <AssetLabel asset={asset} />
                     </div>
                   )}
                 </div>
@@ -471,9 +474,7 @@ export const ChannelTable = () => {
                   {asset && (
                     <div className="text-xs">
                       {formatNumber(asset.localBalance)}{' '}
-                      <span className="text-gray-500">
-                        {asset.assetName || asset.assetId.slice(0, 8)}
-                      </span>
+                      <AssetLabel asset={asset} />
                     </div>
                   )}
                 </div>
@@ -493,9 +494,7 @@ export const ChannelTable = () => {
                   {asset && (
                     <div className="text-xs">
                       {formatNumber(asset.remoteBalance)}{' '}
-                      <span className="text-gray-500">
-                        {asset.assetName || asset.assetId.slice(0, 8)}
-                      </span>
+                      <AssetLabel asset={asset} />
                     </div>
                   )}
                 </div>

--- a/src/client/src/views/channels/channels/ChannelTable.tsx
+++ b/src/client/src/views/channels/channels/ChannelTable.tsx
@@ -706,7 +706,7 @@ export const ChannelTable = () => {
         data={tableData}
         withGlobalSort={true}
         withSorting={true}
-        initSorting={[{ id: 'balanceBars', desc: false }]}
+        initSorting={[{ id: 'balanceBarsLocal', desc: false }]}
         toggleConfiguration={handleToggle}
         defaultHiddenColumns={hiddenColumnState}
         filterPlaceholder="channels"

--- a/src/server/modules/api/channels/channels.resolver.ts
+++ b/src/server/modules/api/channels/channels.resolver.ts
@@ -26,6 +26,7 @@ import { TapdNodeService } from '../../node/tapd/tapd-node.service';
 
 function toAssetField(ac: {
   assetId: string;
+  assetName: string;
   groupKey: string;
   localBalance: string;
   remoteBalance: string;
@@ -33,6 +34,7 @@ function toAssetField(ac: {
 }) {
   return {
     assetId: ac.assetId,
+    assetName: ac.assetName,
     groupKey: ac.groupKey,
     localBalance: ac.localBalance,
     remoteBalance: ac.remoteBalance,

--- a/src/server/modules/api/channels/channels.resolver.ts
+++ b/src/server/modules/api/channels/channels.resolver.ts
@@ -27,17 +27,21 @@ import { TapdNodeService } from '../../node/tapd/tapd-node.service';
 function toAssetField(ac: {
   assetId: string;
   assetName: string;
+  assetType: string;
+  assetPrecision: number;
   groupKey: string;
   localBalance: string;
   remoteBalance: string;
   capacity: string;
 }) {
   return {
-    assetId: ac.assetId,
-    assetName: ac.assetName,
-    groupKey: ac.groupKey,
-    localBalance: ac.localBalance,
-    remoteBalance: ac.remoteBalance,
+    asset_id: ac.assetId,
+    asset_name: ac.assetName,
+    asset_type: ac.assetType,
+    asset_precision: ac.assetPrecision,
+    group_key: ac.groupKey,
+    local_balance: ac.localBalance,
+    remote_balance: ac.remoteBalance,
     capacity: ac.capacity,
   };
 }

--- a/src/server/modules/api/channels/channels.types.ts
+++ b/src/server/modules/api/channels/channels.types.ts
@@ -95,6 +95,8 @@ export class SingleChannel {
 export class ChannelAsset {
   @Field()
   assetId: string;
+  @Field()
+  assetName: string;
   @Field({ nullable: true })
   groupKey?: string;
   @Field()

--- a/src/server/modules/api/channels/channels.types.ts
+++ b/src/server/modules/api/channels/channels.types.ts
@@ -94,15 +94,19 @@ export class SingleChannel {
 @ObjectType()
 export class ChannelAsset {
   @Field()
-  assetId: string;
+  asset_id: string;
   @Field()
-  assetName: string;
+  asset_name: string;
+  @Field()
+  asset_type: string;
+  @Field()
+  asset_precision: number;
   @Field({ nullable: true })
-  groupKey?: string;
+  group_key?: string;
   @Field()
-  localBalance: string;
+  local_balance: string;
   @Field()
-  remoteBalance: string;
+  remote_balance: string;
   @Field()
   capacity: string;
 }

--- a/src/server/modules/api/magma/magma.resolver.ts
+++ b/src/server/modules/api/magma/magma.resolver.ts
@@ -232,8 +232,11 @@ export class MagmaResolver {
           const invoice = order?.payment?.lightning?.invoice;
 
           if (error || !order || !invoice) {
-            if (error)
-              this.logger.error('Magma order creation failed', { error });
+            this.logger.error('Magma order creation failed', {
+              error,
+              orderId: order?.id,
+              hasInvoice: !!invoice,
+            });
             throw new GraphQLError('Failed to create Magma channel order');
           }
 

--- a/src/server/modules/node/tapd/tapd-node.service.ts
+++ b/src/server/modules/node/tapd/tapd-node.service.ts
@@ -47,6 +47,7 @@ type AssetChannelInfo = {
   assetId: string;
   assetName: string;
   assetPrecision: number;
+  assetType: string;
   groupKey: string;
   localBalance: string;
   remoteBalance: string;
@@ -468,6 +469,7 @@ export class TapdNodeService {
                 assetId,
                 assetName: fundingAsset?.asset_genesis?.name || '',
                 assetPrecision: fundingAsset?.decimal_display ?? 0,
+                assetType: fundingAsset?.asset_genesis?.asset_type || 'NORMAL',
                 groupKey,
                 localBalance: String(data.local_balance ?? 0),
                 remoteBalance: String(data.remote_balance ?? 0),
@@ -538,6 +540,7 @@ export class TapdNodeService {
                 assetId,
                 assetName: fundingAsset?.asset_genesis?.name || '',
                 assetPrecision: fundingAsset?.decimal_display ?? 0,
+                assetType: fundingAsset?.asset_genesis?.asset_type || 'NORMAL',
                 groupKey,
                 localBalance: String(data.local_balance ?? 0),
                 remoteBalance: String(data.remote_balance ?? 0),


### PR DESCRIPTION
Fixes a real bug, assets not showing in the channels table.

Also makes some UI improvements.

* Every asset will now get its own color deterministically generated from the hash of its asset id.
* Show bar charts for all assets in the `Bars` column.


<img width="2057" height="385" alt="Screenshot from 2026-04-21 11-35-07" src="https://github.com/user-attachments/assets/654abd15-61a5-42f2-9794-ddc4fc64cc40" />
