### PR TITLE
feat: surface asset precision from channel genesis data

### DIFF
--- a/schema.gql
+++ b/schema.gql
@@ -934,6 +934,7 @@ type TapAssetBalanceEntry {
 type TapAssetChannelBalance {
   asset_id: String!
   asset_name: String
+  asset_precision: Float!
   capacity: String!
   channel_point: String!
   group_key: String

--- a/src/client/src/graphql/queries/getTapAssetChannelBalances.ts
+++ b/src/client/src/graphql/queries/getTapAssetChannelBalances.ts
@@ -9,6 +9,7 @@ export const GET_TAP_ASSET_CHANNEL_BALANCES = gql`
         partner_public_key
         asset_id
         asset_name
+        asset_precision
         group_key
         local_balance
         remote_balance

--- a/src/client/src/views/assets/AssetsList.tsx
+++ b/src/client/src/views/assets/AssetsList.tsx
@@ -19,6 +19,7 @@ type UnifiedEntry = {
   onChainBalance: number;
   channelBalance: number;
   totalBalance: number;
+  precision: number;
   priceEntry: PriceInfo | undefined;
   isAmbossListed: boolean;
 };
@@ -116,7 +117,12 @@ export const AssetsList: FC = () => {
     // 2. Channel balances aggregated by group_key (falling back to asset_id)
     const channelMap = new Map<
       string,
-      { localBalance: number; names: string[]; hasGroupKey: boolean }
+      {
+        localBalance: number;
+        names: string[];
+        hasGroupKey: boolean;
+        precision: number;
+      }
     >();
     for (const ch of channels) {
       const key = ch.group_key || ch.asset_id;
@@ -132,6 +138,7 @@ export const AssetsList: FC = () => {
           localBalance: localBal,
           names: ch.asset_name ? [ch.asset_name] : [],
           hasGroupKey: !!ch.group_key,
+          precision: ch.asset_precision ?? 0,
         });
       }
     }
@@ -154,6 +161,8 @@ export const AssetsList: FC = () => {
         : (channel?.names ?? []);
 
       const hasGroupKey = onChain?.hasGroupKey || channel?.hasGroupKey;
+      const priceEntry = priceMap.get(key);
+      const precision = channel?.precision ?? priceEntry?.precision ?? 0;
 
       merged.push({
         key,
@@ -162,7 +171,8 @@ export const AssetsList: FC = () => {
         onChainBalance,
         channelBalance,
         totalBalance,
-        priceEntry: priceMap.get(key),
+        precision,
+        priceEntry,
         isAmbossListed: supportedKeys.has(key),
       });
     }
@@ -210,7 +220,7 @@ export const AssetsList: FC = () => {
       <div className="grid gap-3">
         {unified.map(entry => {
           const usdValue = entry.priceEntry
-            ? (entry.totalBalance / 10 ** entry.priceEntry.precision) *
+            ? (entry.totalBalance / 10 ** entry.precision) *
               entry.priceEntry.usd
             : null;
 
@@ -241,40 +251,23 @@ export const AssetsList: FC = () => {
 
                   <div className="flex flex-col items-end gap-1 shrink-0">
                     <span className="text-lg font-semibold">
-                      {entry.priceEntry
-                        ? formatBalance(
-                            entry.totalBalance,
-                            entry.priceEntry.precision
-                          )
-                        : entry.totalBalance.toString()}
+                      {formatBalance(entry.totalBalance, entry.precision)}
                     </span>
                     {usdValue != null && (
                       <span className="text-xs text-muted-foreground">
                         ≈ ${formatUsd(usdValue)}
                       </span>
                     )}
-                    {hasBothSources(entry) && entry.priceEntry && (
+                    {hasBothSources(entry) && (
                       <div className="flex flex-col items-end gap-0.5 text-[11px] text-muted-foreground/70">
                         <span>
                           On-chain:{' '}
-                          {formatBalance(
-                            entry.onChainBalance,
-                            entry.priceEntry.precision
-                          )}
+                          {formatBalance(entry.onChainBalance, entry.precision)}
                         </span>
                         <span>
                           Channel:{' '}
-                          {formatBalance(
-                            entry.channelBalance,
-                            entry.priceEntry.precision
-                          )}
+                          {formatBalance(entry.channelBalance, entry.precision)}
                         </span>
-                      </div>
-                    )}
-                    {hasBothSources(entry) && !entry.priceEntry && (
-                      <div className="flex flex-col items-end gap-0.5 text-[11px] text-muted-foreground/70">
-                        <span>On-chain: {entry.onChainBalance}</span>
-                        <span>Channel: {entry.channelBalance}</span>
                       </div>
                     )}
                   </div>

--- a/src/server/modules/api/tapd/tapd.resolver.ts
+++ b/src/server/modules/api/tapd/tapd.resolver.ts
@@ -392,6 +392,7 @@ export class TaprootAssetsQueriesResolver {
       partner_public_key: b.partnerPublicKey,
       asset_id: b.assetId,
       asset_name: b.assetName || null,
+      asset_precision: b.assetPrecision,
       group_key: b.groupKey || null,
       local_balance: b.localBalance,
       remote_balance: b.remoteBalance,

--- a/src/server/modules/api/tapd/tapd.types.ts
+++ b/src/server/modules/api/tapd/tapd.types.ts
@@ -389,6 +389,9 @@ export class TapAssetChannelBalance {
   @Field({ nullable: true })
   asset_name?: string;
 
+  @Field()
+  asset_precision: number;
+
   @Field({ nullable: true })
   group_key?: string;
 

--- a/src/server/modules/node/tapd/tapd-node.service.ts
+++ b/src/server/modules/node/tapd/tapd-node.service.ts
@@ -45,6 +45,7 @@ type AssetChannelInfo = {
   partnerPublicKey: string;
   assetId: string;
   assetName: string;
+  assetPrecision: number;
   groupKey: string;
   localBalance: string;
   remoteBalance: string;
@@ -454,6 +455,7 @@ export class TapdNodeService {
                 partnerPublicKey: ch.remote_pubkey,
                 assetId,
                 assetName: fundingAsset?.asset_genesis?.name || '',
+                assetPrecision: fundingAsset?.decimal_display ?? 0,
                 groupKey,
                 localBalance: String(data.local_balance ?? 0),
                 remoteBalance: String(data.remote_balance ?? 0),
@@ -523,6 +525,7 @@ export class TapdNodeService {
                 partnerPublicKey: ch.remote_node_pub,
                 assetId,
                 assetName: fundingAsset?.asset_genesis?.name || '',
+                assetPrecision: fundingAsset?.decimal_display ?? 0,
                 groupKey,
                 localBalance: String(data.local_balance ?? 0),
                 remoteBalance: String(data.remote_balance ?? 0),


### PR DESCRIPTION
Reads decimal_display from the funding asset genesis embedded in custom_channel_data, so unlisted assets display formatted balances without depending on Amboss. Genesis precision is preferred over Amboss when both are available, as it is protocol-authoritative. Amboss remains the fallback for on-chain-only assets with no channels.