### PR TITLE
fix: move is_private into options for Magma order

### DIFF
--- a/src/server/modules/api/magma/magma.resolver.spec.ts
+++ b/src/server/modules/api/magma/magma.resolver.spec.ts
@@ -367,7 +367,7 @@ describe('MagmaResolver', () => {
           magmaUrl,
           expect.anything(),
           expect.objectContaining({
-            input: expect.objectContaining({ size: '1000', is_private: true }),
+            input: expect.objectContaining({ size: '1000' }),
           }),
           expect.any(Object)
         );
@@ -433,7 +433,7 @@ describe('MagmaResolver', () => {
           magmaUrl,
           expect.anything(),
           expect.objectContaining({
-            input: expect.objectContaining({ size: '1000', is_private: true }),
+            input: expect.objectContaining({ size: '1000' }),
           }),
           expect.any(Object)
         );

--- a/src/server/modules/api/magma/magma.resolver.ts
+++ b/src/server/modules/api/magma/magma.resolver.ts
@@ -222,8 +222,10 @@ export class MagmaResolver {
                   pubkey: nodeInfo.publicKey,
                   size: magmaSize,
                   payment_method: 'SATS',
-                  is_private: true,
-                  options: { asset_id: input.ambossAssetId },
+                  options: {
+                    asset_id: input.ambossAssetId,
+                    private: true,
+                  },
                 },
               },
               { authorization: `Bearer ${ambossAuth}` }


### PR DESCRIPTION
## Summary
- Moves `is_private: true` from the top-level `CreateManualOrderInput` into the `options` object, matching the Magma GraphQL schema at `magma.amboss.tech/graphql`
- Fixes: `Field "is_private" is not defined by type "CreateManualOrderInput"`

## Test plan
- [x] Existing magma resolver tests pass (23/23)