### PR TITLE
fix: correct asset/BTC rate ticker order in trading UI

### DIFF
--- a/src/client/src/views/assets/TradeSheet.tsx
+++ b/src/client/src/views/assets/TradeSheet.tsx
@@ -550,7 +550,7 @@ export const TradeSheet: FC<TradeSheetProps> = ({
                 <div className="flex justify-between">
                   <span className="text-muted-foreground">Rate</span>
                   <span>
-                    {rateDisplay} {assetSymbol}/BTC
+                    {rateDisplay} BTC/{assetSymbol}
                   </span>
                 </div>
               )}
@@ -780,7 +780,7 @@ export const TradeSheet: FC<TradeSheetProps> = ({
                 <div className="flex justify-between">
                   <span className="text-muted-foreground">Rate</span>
                   <span>
-                    {rateDisplay} {assetSymbol}/BTC
+                    {rateDisplay} BTC/{assetSymbol}
                   </span>
                 </div>
               )}

--- a/src/client/src/views/assets/TradingOffers.tsx
+++ b/src/client/src/views/assets/TradingOffers.tsx
@@ -509,7 +509,7 @@ export const TradingOffers: FC = () => {
                   className="text-left py-3 px-3 font-medium cursor-pointer select-none"
                   onClick={() => toggleSort(TapOfferSortBy.Rate)}
                 >
-                  {selectedSymbol ? `${selectedSymbol}/BTC` : 'Rate'}
+                  {selectedSymbol ? `BTC/${selectedSymbol}` : 'Rate'}
                   <SortIcon field={TapOfferSortBy.Rate} activeSortBy={sortBy} />
                 </th>
                 <th


### PR DESCRIPTION
Rate is expressed as asset units per BTC, so the pair should be displayed as BTC/ASSET (base/quote), not ASSET/BTC.