### PR TITLE
fix: respect word boundaries in toast messages

### DIFF
--- a/src/client/src/utils/error.tsx
+++ b/src/client/src/utils/error.tsx
@@ -36,7 +36,7 @@ export const getErrorContent = (error: ApolloError): JSX.Element => {
     <div>
       {errors.map((errorMsg, i) => {
         return (
-          <div key={i} className="py-1 break-all">
+          <div key={i} className="py-1 break-words">
             {getMessage(errorMsg)}
           </div>
         );


### PR DESCRIPTION
Adds `wordBreak: 'break-word'` to global `Toaster` options so toast messages wrap at word boundaries instead of breaking mid-word.

