### PR TITLE
chore: circular rebalance for TA channel sat reserve

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,7 @@
         "js-yaml": "^4.1.1",
         "jsonwebtoken": "^9.0.3",
         "light-bolt11-decoder": "^3.2.0",
-        "lightning": "git://github.com/ambossTech/lightning.git#cf10b33bb9866f9e976979a84f3adeccc89bbb64",
+        "lightning": "^11.0.4",
         "lodash": "^4.17.23",
         "lucide-react": "^0.577.0",
         "nest-winston": "^1.10.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,7 @@
         "js-yaml": "^4.1.1",
         "jsonwebtoken": "^9.0.3",
         "light-bolt11-decoder": "^3.2.0",
-        "lightning": "^11.0.4",
+        "lightning": "git://github.com/ambossTech/lightning.git#cf10b33bb9866f9e976979a84f3adeccc89bbb64",
         "lodash": "^4.17.23",
         "lucide-react": "^0.577.0",
         "nest-winston": "^1.10.2",
@@ -8883,12 +8883,12 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.5.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.2.tgz",
-      "integrity": "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg==",
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.18.0"
+        "undici-types": "~7.19.0"
       }
     },
     "node_modules/@types/randombytes": {
@@ -16456,15 +16456,15 @@
       "license": "MIT"
     },
     "node_modules/lightning": {
-      "version": "11.0.4",
-      "resolved": "https://registry.npmjs.org/lightning/-/lightning-11.0.4.tgz",
-      "integrity": "sha512-fJInoksqwBxbchtL5Sq/DeX53DhjkKyyV+/6amHx2/gQzwUwZZTckwS+6daluXLeLTb0v20L6/yHTT6I97lVBQ==",
+      "version": "11.0.5",
+      "resolved": "git+ssh://git@github.com/ambossTech/lightning.git#cf10b33bb9866f9e976979a84f3adeccc89bbb64",
+      "integrity": "sha512-WdnB6PqN5FRtziXSBv/uh85ii166dny7OHv28N1VnyuP5o3UkEJUjqejFEi4oQmHsGSaWiWsBHI0T3eyCRYbeQ==",
       "license": "MIT",
       "dependencies": {
         "@alexbosworth/blockchain": "3.2.0",
         "@grpc/grpc-js": "1.14.3",
         "@grpc/proto-loader": "0.8.0",
-        "@types/node": "25.5.2",
+        "@types/node": "25.6.0",
         "@types/request": "2.48.13",
         "@types/ws": "8.18.1",
         "async": "3.2.6",
@@ -16474,7 +16474,7 @@
         "bolt09": "2.2.0",
         "invoices": "5.0.2",
         "psbt": "5.0.0",
-        "type-fest": "5.5.0"
+        "type-fest": "5.6.0"
       },
       "engines": {
         "node": ">=20"
@@ -16489,9 +16489,9 @@
       }
     },
     "node_modules/lightning/node_modules/type-fest": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.5.0.tgz",
-      "integrity": "sha512-PlBfpQwiUvGViBNX84Yxwjsdhd1TUlXr6zjX7eoirtCPIr08NAmxwa+fcYBTeRQxHo9YC9wwF3m9i700sHma8g==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.6.0.tgz",
+      "integrity": "sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==",
       "license": "(MIT OR CC0-1.0)",
       "dependencies": {
         "tagged-tag": "^1.0.0"
@@ -21831,9 +21831,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
-      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
       "license": "MIT"
     },
     "node_modules/unicorn-magic": {

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "js-yaml": "^4.1.1",
     "jsonwebtoken": "^9.0.3",
     "light-bolt11-decoder": "^3.2.0",
-    "lightning": "^11.0.4",
+    "lightning": "git://github.com/ambossTech/lightning.git#cf10b33bb9866f9e976979a84f3adeccc89bbb64",
     "lodash": "^4.17.23",
     "lucide-react": "^0.577.0",
     "nest-winston": "^1.10.2",

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "js-yaml": "^4.1.1",
     "jsonwebtoken": "^9.0.3",
     "light-bolt11-decoder": "^3.2.0",
-    "lightning": "git://github.com/ambossTech/lightning.git#cf10b33bb9866f9e976979a84f3adeccc89bbb64",
+    "lightning": "^11.0.4",
     "lodash": "^4.17.23",
     "lucide-react": "^0.577.0",
     "nest-winston": "^1.10.2",

--- a/src/server/modules/api/trade/trade.resolver.spec.ts
+++ b/src/server/modules/api/trade/trade.resolver.spec.ts
@@ -55,8 +55,10 @@ interface PrivateMethods {
     taChannelScid: string,
     taChannelPartnerScidAlias: string | undefined,
     taChannelCapacity: number,
-    btcChannels: BtcChannel[],
-    rebalanceSats: number
+    btcChannel: BtcChannel,
+    rebalanceSats: number,
+    currentHeight: number,
+    identityPubkey: string
   ): Promise<void>;
 }
 
@@ -367,7 +369,6 @@ describe('TradeResolver', () => {
       capacity: 1_000_000,
       local_balance: 300_000,
       local_reserve: 1_062,
-      other_ids: [],
       remote_balance: 700_000,
       transaction_id: 'aabb'.repeat(16),
       transaction_vout: 0,
@@ -564,15 +565,14 @@ describe('TradeResolver', () => {
   describe('rebalanceTaChannel', () => {
     const taChannelScid = '800000x1x0';
     const taChannelCapacity = 1_000_000;
-    const btcChannels: BtcChannel[] = [
-      {
-        id: 'btc-1',
-        capacity: 2_000_000,
-        local_balance: 500_000,
-        remote_balance: 300_000,
-      },
-    ];
+    const btcChannel: BtcChannel = {
+      id: 'btc-1',
+      capacity: 2_000_000,
+      local_balance: 500_000,
+      remote_balance: 300_000,
+    };
     const rebalanceSats = 1_200;
+    const currentHeight = 800_000;
 
     it('builds correct 2-hop route and calls payViaRoutes', async () => {
       await priv.rebalanceTaChannel(
@@ -581,8 +581,10 @@ describe('TradeResolver', () => {
         taChannelScid,
         undefined,
         taChannelCapacity,
-        btcChannels,
-        rebalanceSats
+        btcChannel,
+        rebalanceSats,
+        currentHeight,
+        myPubkey
       );
 
       expect(mockNodeService.payViaRoutes).toHaveBeenCalledTimes(1);
@@ -601,10 +603,10 @@ describe('TradeResolver', () => {
       const [hop1, hop2] = routes[0].hops;
       expect(hop1.channel).toBe('btc-1');
       expect(hop1.public_key).toBe(peerPubkey);
-      expect(hop1.fee).toBe(0);
+      expect(hop1.fee).toBeGreaterThan(0);
       expect(hop2.channel).toBe(taChannelScid);
       expect(hop2.public_key).toBe(myPubkey);
-      expect(hop2.fee).toBeGreaterThan(0);
+      expect(hop2.fee).toBe(0);
       expect(hop1.timeout).toBe(hop2.timeout);
       expect(routes[0].timeout).toBeGreaterThan(hop1.timeout);
     });
@@ -616,8 +618,10 @@ describe('TradeResolver', () => {
         taChannelScid,
         undefined,
         taChannelCapacity,
-        btcChannels,
-        rebalanceSats
+        btcChannel,
+        rebalanceSats,
+        currentHeight,
+        myPubkey
       );
 
       const routes = mockNodeService.payViaRoutes.mock.calls[0][1]
@@ -632,63 +636,6 @@ describe('TradeResolver', () => {
       expect(routes[0].timeout).toBe(800_067);
     });
 
-    it('throws when BTC local_balance < rebalanceSats', async () => {
-      const insufficientChannels: BtcChannel[] = [
-        {
-          id: 'btc-1',
-          capacity: 2_000_000,
-          local_balance: 100,
-          remote_balance: 1_000_000,
-        },
-      ];
-
-      await expect(
-        priv.rebalanceTaChannel(
-          userId,
-          peerPubkey,
-          taChannelScid,
-          undefined,
-          taChannelCapacity,
-          insufficientChannels,
-          rebalanceSats
-        )
-      ).rejects.toThrow(
-        'Insufficient BTC local balance for circular rebalance'
-      );
-    });
-
-    it('throws when getHeight fails', async () => {
-      mockNodeService.getHeight.mockRejectedValue(new Error('rpc down'));
-
-      await expect(
-        priv.rebalanceTaChannel(
-          userId,
-          peerPubkey,
-          taChannelScid,
-          undefined,
-          taChannelCapacity,
-          btcChannels,
-          rebalanceSats
-        )
-      ).rejects.toThrow('could not get current block height');
-    });
-
-    it('throws when getIdentity fails', async () => {
-      mockNodeService.getIdentity.mockRejectedValue(new Error('rpc down'));
-
-      await expect(
-        priv.rebalanceTaChannel(
-          userId,
-          peerPubkey,
-          taChannelScid,
-          undefined,
-          taChannelCapacity,
-          btcChannels,
-          rebalanceSats
-        )
-      ).rejects.toThrow('could not get node identity');
-    });
-
     it('throws when createInvoice fails', async () => {
       mockNodeService.createInvoice.mockRejectedValue(new Error('rpc down'));
 
@@ -699,8 +646,10 @@ describe('TradeResolver', () => {
           taChannelScid,
           undefined,
           taChannelCapacity,
-          btcChannels,
-          rebalanceSats
+          btcChannel,
+          rebalanceSats,
+          currentHeight,
+          myPubkey
         )
       ).rejects.toThrow('could not create self-payment invoice');
     });
@@ -717,8 +666,10 @@ describe('TradeResolver', () => {
           taChannelScid,
           undefined,
           taChannelCapacity,
-          btcChannels,
-          rebalanceSats
+          btcChannel,
+          rebalanceSats,
+          currentHeight,
+          myPubkey
         )
       ).rejects.toThrow('Circular rebalance payment failed');
     });
@@ -733,8 +684,10 @@ describe('TradeResolver', () => {
           taChannelScid,
           undefined,
           taChannelCapacity,
-          btcChannels,
-          rebalanceSats
+          btcChannel,
+          rebalanceSats,
+          currentHeight,
+          myPubkey
         )
       ).rejects.toThrow('did not confirm');
     });
@@ -747,8 +700,10 @@ describe('TradeResolver', () => {
           taChannelScid,
           undefined,
           taChannelCapacity,
-          btcChannels,
-          rebalanceSats
+          btcChannel,
+          rebalanceSats,
+          currentHeight,
+          myPubkey
         )
       ).resolves.toBeUndefined();
     });
@@ -778,8 +733,10 @@ describe('TradeResolver', () => {
         taChannelScid,
         undefined,
         taChannelCapacity,
-        btcChannels,
-        rebalanceSats
+        btcChannel,
+        rebalanceSats,
+        currentHeight,
+        myPubkey
       );
 
       const routes = mockNodeService.payViaRoutes.mock.calls[0][1]

--- a/src/server/modules/api/trade/trade.resolver.spec.ts
+++ b/src/server/modules/api/trade/trade.resolver.spec.ts
@@ -53,7 +53,7 @@ interface PrivateMethods {
     id: string,
     peerPubkey: string,
     taChannelScid: string,
-    taChannelPartnerScid: string | undefined,
+    taChannelPartnerScidAlias: string | undefined,
     taChannelCapacity: number,
     btcChannels: BtcChannel[],
     rebalanceSats: number

--- a/src/server/modules/api/trade/trade.resolver.spec.ts
+++ b/src/server/modules/api/trade/trade.resolver.spec.ts
@@ -10,13 +10,7 @@ jest.mock('../../security/security.decorators', () => ({
 jest.mock('../../security/security.types', () => ({}));
 
 import { TradeResolver } from './trade.resolver';
-
-type BtcChannel = {
-  id: string;
-  capacity: number;
-  local_balance: number;
-  remote_balance: number;
-};
+import { BtcChannel, TaChannel } from './trade.types';
 
 type RouteHop = {
   public_key: string;
@@ -41,6 +35,29 @@ interface PrivateMethods {
     rate: { coefficient: string; scale: number },
     minTransportableMsat: string
   ): number;
+  findTaChannelsForAsset(
+    id: string,
+    peerPubkey: string,
+    assetId: string | undefined,
+    groupKey: string | undefined
+  ): Promise<
+    Array<{
+      scid: string;
+      partnerScidAlias: string | undefined;
+      capacity: number;
+      localBalance: number;
+      localReserve: number;
+    }>
+  >;
+  rebalanceTaChannel(
+    id: string,
+    peerPubkey: string,
+    taChannelScid: string,
+    taChannelPartnerScid: string | undefined,
+    taChannelCapacity: number,
+    btcChannels: BtcChannel[],
+    rebalanceSats: number
+  ): Promise<void>;
 }
 
 describe('TradeResolver', () => {
@@ -52,8 +69,13 @@ describe('TradeResolver', () => {
     getChannels: jest.fn(),
     getChannel: jest.fn(),
     getIdentity: jest.fn(),
+    getHeight: jest.fn(),
+    createInvoice: jest.fn(),
+    payViaRoutes: jest.fn(),
   };
-  const mockTapdNodeService = {};
+  const mockTapdNodeService = {
+    getAssetChannelBalances: jest.fn(),
+  };
   const mockLogger = { error: jest.fn(), warn: jest.fn(), info: jest.fn() };
 
   let resolver: TradeResolver;
@@ -66,6 +88,17 @@ describe('TradeResolver', () => {
     mockNodeService.getChannel.mockRejectedValue(
       new Error('channel not in graph')
     );
+    mockNodeService.getHeight.mockResolvedValue({
+      current_block_height: 800_000,
+    });
+    mockNodeService.createInvoice.mockResolvedValue({
+      id: 'aa'.repeat(32),
+      payment: 'bb'.repeat(32),
+      request: 'lnbc...',
+      secret: 'cc'.repeat(32),
+    });
+    mockNodeService.payViaRoutes.mockResolvedValue({ is_confirmed: true });
+    mockTapdNodeService.getAssetChannelBalances.mockResolvedValue([]);
     resolver = new TradeResolver(
       mockTapdNodeService as never,
       mockNodeService as never,
@@ -320,6 +353,442 @@ describe('TradeResolver', () => {
         channel: '222x2x0',
         cltv_delta: 100,
       });
+    });
+  });
+
+  // ── findTaChannelForAsset ──
+
+  describe('findTaChannelForAsset', () => {
+    const assetId = 'ff'.repeat(32);
+    const groupKey = 'ee'.repeat(33);
+
+    const makeTaChannel = (overrides: Partial<TaChannel> = {}): TaChannel => ({
+      id: 'ta-scid-1',
+      capacity: 1_000_000,
+      local_balance: 300_000,
+      local_reserve: 1_062,
+      other_ids: [],
+      remote_balance: 700_000,
+      transaction_id: 'aabb'.repeat(16),
+      transaction_vout: 0,
+      ...overrides,
+    });
+
+    it('returns the matching TA channel by assetId via channelPoint join', async () => {
+      const taChannel = makeTaChannel();
+      mockNodeService.getChannels.mockResolvedValue({
+        channels: [
+          {
+            id: 'btc-1',
+            type: 'anchor',
+            capacity: 2_000_000,
+            local_balance: 1_000_000,
+            remote_balance: 1_000_000,
+          },
+          { ...taChannel, type: undefined },
+        ],
+      });
+      mockTapdNodeService.getAssetChannelBalances.mockResolvedValue([
+        {
+          channelPoint: `${taChannel.transaction_id}:${taChannel.transaction_vout}`,
+          assetId,
+          groupKey: '',
+        },
+      ]);
+
+      const result = await priv.findTaChannelsForAsset(
+        userId,
+        peerPubkey,
+        assetId,
+        undefined
+      );
+
+      expect(result).toEqual([
+        {
+          scid: taChannel.id,
+          partnerScidAlias: undefined,
+          capacity: taChannel.capacity,
+          localBalance: taChannel.local_balance,
+          localReserve: taChannel.local_reserve,
+        },
+      ]);
+    });
+
+    it('returns empty array when assetId does not match any TA channel', async () => {
+      const taChannel = makeTaChannel();
+      mockNodeService.getChannels.mockResolvedValue({
+        channels: [{ ...taChannel, type: undefined }],
+      });
+      mockTapdNodeService.getAssetChannelBalances.mockResolvedValue([
+        {
+          channelPoint: `${taChannel.transaction_id}:${taChannel.transaction_vout}`,
+          assetId: 'cc'.repeat(32),
+          groupKey: '',
+        },
+      ]);
+
+      const result = await priv.findTaChannelsForAsset(
+        userId,
+        peerPubkey,
+        assetId,
+        undefined
+      );
+
+      expect(result).toEqual([]);
+    });
+
+    it('matches by groupKey when assetId is undefined', async () => {
+      const taChannel = makeTaChannel();
+      mockNodeService.getChannels.mockResolvedValue({
+        channels: [{ ...taChannel, type: undefined }],
+      });
+      mockTapdNodeService.getAssetChannelBalances.mockResolvedValue([
+        {
+          channelPoint: `${taChannel.transaction_id}:${taChannel.transaction_vout}`,
+          assetId: 'dd'.repeat(32),
+          groupKey,
+        },
+      ]);
+
+      const result = await priv.findTaChannelsForAsset(
+        userId,
+        peerPubkey,
+        undefined,
+        groupKey
+      );
+
+      expect(result[0]?.scid).toBe(taChannel.id);
+    });
+
+    it('returns empty array and logs warning when getChannels fails', async () => {
+      mockNodeService.getChannels.mockRejectedValue(new Error('rpc down'));
+
+      const result = await priv.findTaChannelsForAsset(
+        userId,
+        peerPubkey,
+        assetId,
+        undefined
+      );
+
+      expect(result).toEqual([]);
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        'Failed to fetch TA channel info with peer',
+        expect.any(Object)
+      );
+    });
+
+    it('returns empty array and logs warning when getAssetChannelBalances fails', async () => {
+      const taChannel = makeTaChannel();
+      mockNodeService.getChannels.mockResolvedValue({
+        channels: [{ ...taChannel, type: undefined }],
+      });
+      mockTapdNodeService.getAssetChannelBalances.mockRejectedValue(
+        new Error('tapd down')
+      );
+
+      const result = await priv.findTaChannelsForAsset(
+        userId,
+        peerPubkey,
+        assetId,
+        undefined
+      );
+
+      expect(result).toEqual([]);
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        'Failed to fetch asset channel balances with peer',
+        expect.any(Object)
+      );
+    });
+
+    it('matches by groupKey when both assetId and groupKey are provided (groupKey wins)', async () => {
+      const taChannel = makeTaChannel();
+      mockNodeService.getChannels.mockResolvedValue({
+        channels: [{ ...taChannel, type: undefined }],
+      });
+      mockTapdNodeService.getAssetChannelBalances.mockResolvedValue([
+        {
+          channelPoint: `${taChannel.transaction_id}:${taChannel.transaction_vout}`,
+          assetId: 'dd'.repeat(32), // different assetId — should be ignored
+          groupKey,
+        },
+      ]);
+
+      const result = await priv.findTaChannelsForAsset(
+        userId,
+        peerPubkey,
+        assetId,
+        groupKey
+      );
+
+      expect(result[0]?.scid).toBe(taChannel.id);
+    });
+
+    it('returns empty array immediately when neither assetId nor groupKey is provided', async () => {
+      const result = await priv.findTaChannelsForAsset(
+        userId,
+        peerPubkey,
+        undefined,
+        undefined
+      );
+
+      expect(result).toEqual([]);
+      expect(mockNodeService.getChannels).not.toHaveBeenCalled();
+    });
+
+    it('returns empty array when all channels are BTC type (no TA channels)', async () => {
+      mockNodeService.getChannels.mockResolvedValue({
+        channels: [
+          {
+            id: 'btc-1',
+            type: 'anchor',
+            capacity: 2_000_000,
+            local_balance: 1_000_000,
+            remote_balance: 1_000_000,
+          },
+        ],
+      });
+
+      const result = await priv.findTaChannelsForAsset(
+        userId,
+        peerPubkey,
+        assetId,
+        undefined
+      );
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  // ── rebalanceTaChannel ──
+
+  describe('rebalanceTaChannel', () => {
+    const taChannelScid = '800000x1x0';
+    const taChannelCapacity = 1_000_000;
+    const btcChannels: BtcChannel[] = [
+      {
+        id: 'btc-1',
+        capacity: 2_000_000,
+        local_balance: 500_000,
+        remote_balance: 300_000,
+      },
+    ];
+    const rebalanceSats = 1_200;
+
+    it('builds correct 2-hop route and calls payViaRoutes', async () => {
+      await priv.rebalanceTaChannel(
+        userId,
+        peerPubkey,
+        taChannelScid,
+        undefined,
+        taChannelCapacity,
+        btcChannels,
+        rebalanceSats
+      );
+
+      expect(mockNodeService.payViaRoutes).toHaveBeenCalledTimes(1);
+      const call = mockNodeService.payViaRoutes.mock.calls[0];
+      const routes: Array<{
+        hops: Array<{
+          channel: string;
+          public_key: string;
+          fee: number;
+          timeout: number;
+        }>;
+        timeout: number;
+      }> = call[1].routes;
+
+      expect(routes).toHaveLength(1);
+      const [hop1, hop2] = routes[0].hops;
+      expect(hop1.channel).toBe('btc-1');
+      expect(hop1.public_key).toBe(peerPubkey);
+      expect(hop1.fee).toBe(0);
+      expect(hop2.channel).toBe(taChannelScid);
+      expect(hop2.public_key).toBe(myPubkey);
+      expect(hop2.fee).toBeGreaterThan(0);
+      expect(hop1.timeout).toBe(hop2.timeout);
+      expect(routes[0].timeout).toBeGreaterThan(hop1.timeout);
+    });
+
+    it('uses cltv_delta fallback of 40 when both getChannel calls fail', async () => {
+      await priv.rebalanceTaChannel(
+        userId,
+        peerPubkey,
+        taChannelScid,
+        undefined,
+        taChannelCapacity,
+        btcChannels,
+        rebalanceSats
+      );
+
+      const routes = mockNodeService.payViaRoutes.mock.calls[0][1]
+        .routes as Array<{
+        hops: Array<{ timeout: number }>;
+        timeout: number;
+      }>;
+      const hop2Timeout = routes[0].hops[0].timeout;
+      // hop2Timeout = 800_000 + 24 (DEFAULT_INVOICE_CLTV_DELTA) + 3 = 800_027
+      expect(hop2Timeout).toBe(800_027);
+      // routes[0].timeout = hop2Timeout + max(40, 40) (DEFAULT_CHANNEL_CLTV_DELTA) = 800_067
+      expect(routes[0].timeout).toBe(800_067);
+    });
+
+    it('throws when BTC local_balance < rebalanceSats', async () => {
+      const insufficientChannels: BtcChannel[] = [
+        {
+          id: 'btc-1',
+          capacity: 2_000_000,
+          local_balance: 100,
+          remote_balance: 1_000_000,
+        },
+      ];
+
+      await expect(
+        priv.rebalanceTaChannel(
+          userId,
+          peerPubkey,
+          taChannelScid,
+          undefined,
+          taChannelCapacity,
+          insufficientChannels,
+          rebalanceSats
+        )
+      ).rejects.toThrow(
+        'Insufficient BTC local balance for circular rebalance'
+      );
+    });
+
+    it('throws when getHeight fails', async () => {
+      mockNodeService.getHeight.mockRejectedValue(new Error('rpc down'));
+
+      await expect(
+        priv.rebalanceTaChannel(
+          userId,
+          peerPubkey,
+          taChannelScid,
+          undefined,
+          taChannelCapacity,
+          btcChannels,
+          rebalanceSats
+        )
+      ).rejects.toThrow('could not get current block height');
+    });
+
+    it('throws when getIdentity fails', async () => {
+      mockNodeService.getIdentity.mockRejectedValue(new Error('rpc down'));
+
+      await expect(
+        priv.rebalanceTaChannel(
+          userId,
+          peerPubkey,
+          taChannelScid,
+          undefined,
+          taChannelCapacity,
+          btcChannels,
+          rebalanceSats
+        )
+      ).rejects.toThrow('could not get node identity');
+    });
+
+    it('throws when createInvoice fails', async () => {
+      mockNodeService.createInvoice.mockRejectedValue(new Error('rpc down'));
+
+      await expect(
+        priv.rebalanceTaChannel(
+          userId,
+          peerPubkey,
+          taChannelScid,
+          undefined,
+          taChannelCapacity,
+          btcChannels,
+          rebalanceSats
+        )
+      ).rejects.toThrow('could not create self-payment invoice');
+    });
+
+    it('throws when payViaRoutes throws', async () => {
+      mockNodeService.payViaRoutes.mockImplementation(() => {
+        throw ['503', 'FAILURE_REASON_INSUFFICIENT_BALANCE', { failures: [] }];
+      });
+
+      await expect(
+        priv.rebalanceTaChannel(
+          userId,
+          peerPubkey,
+          taChannelScid,
+          undefined,
+          taChannelCapacity,
+          btcChannels,
+          rebalanceSats
+        )
+      ).rejects.toThrow('Circular rebalance payment failed');
+    });
+
+    it('throws when payViaRoutes resolves is_confirmed: false', async () => {
+      mockNodeService.payViaRoutes.mockResolvedValue({ is_confirmed: false });
+
+      await expect(
+        priv.rebalanceTaChannel(
+          userId,
+          peerPubkey,
+          taChannelScid,
+          undefined,
+          taChannelCapacity,
+          btcChannels,
+          rebalanceSats
+        )
+      ).rejects.toThrow('did not confirm');
+    });
+
+    it('resolves without error on success', async () => {
+      await expect(
+        priv.rebalanceTaChannel(
+          userId,
+          peerPubkey,
+          taChannelScid,
+          undefined,
+          taChannelCapacity,
+          btcChannels,
+          rebalanceSats
+        )
+      ).resolves.toBeUndefined();
+    });
+
+    it('computes zero fees and correct tokens when peer policy has zero fee', async () => {
+      mockNodeService.getChannel.mockResolvedValue({
+        id: 'btc-1',
+        policies: [
+          {
+            public_key: peerPubkey,
+            base_fee_mtokens: '0',
+            fee_rate: 0,
+            cltv_delta: 40,
+          },
+          {
+            public_key: myPubkey,
+            base_fee_mtokens: '0',
+            fee_rate: 0,
+            cltv_delta: 40,
+          },
+        ],
+      });
+
+      await priv.rebalanceTaChannel(
+        userId,
+        peerPubkey,
+        taChannelScid,
+        undefined,
+        taChannelCapacity,
+        btcChannels,
+        rebalanceSats
+      );
+
+      const routes = mockNodeService.payViaRoutes.mock.calls[0][1]
+        .routes as Array<{
+        fee: number;
+        tokens: number;
+      }>;
+      expect(routes[0].fee).toBe(0);
+      expect(routes[0].tokens).toBe(rebalanceSats);
     });
   });
 

--- a/src/server/modules/api/trade/trade.resolver.ts
+++ b/src/server/modules/api/trade/trade.resolver.ts
@@ -667,21 +667,21 @@ export class TradeResolver {
     for (const taChannel of taChannels) {
       // Need enough local sats above the commitment reserve to transport the
       // asset HTLC. SATS_RESERVE_BUFFER_PCT provides the headroom above this.
-      const effectiveReserve = taChannel.localReserve + invoiceSats;
+      const minRequiredBalance = taChannel.localReserve + invoiceSats;
 
       this.logger.info('ensureTaChannelSatReserve: channel balance check', {
         taChannelScid: taChannel.scid,
         localBalance: taChannel.localBalance,
         localReserve: taChannel.localReserve,
         invoiceSats,
-        effectiveReserve,
-        needsRebalance: taChannel.localBalance < effectiveReserve,
+        minRequiredBalance,
+        needsRebalance: taChannel.localBalance < minRequiredBalance,
       });
 
-      if (taChannel.localBalance >= effectiveReserve) continue;
+      if (taChannel.localBalance >= minRequiredBalance) continue;
 
       const rebalanceSats =
-        Math.ceil(effectiveReserve * (1 + SATS_RESERVE_BUFFER_PCT / 100)) -
+        Math.ceil(minRequiredBalance * (1 + SATS_RESERVE_BUFFER_PCT / 100)) -
         taChannel.localBalance;
 
       this.logger.info(
@@ -690,7 +690,7 @@ export class TradeResolver {
           taChannelScid: taChannel.scid,
           localBalance: taChannel.localBalance,
           localReserve: taChannel.localReserve,
-          effectiveReserve,
+          minRequiredBalance,
           rebalanceSats,
         }
       );
@@ -700,7 +700,7 @@ export class TradeResolver {
           id,
           peerPubkey,
           taChannel.scid,
-          taChannel.peerAlias,
+          taChannel.partnerScidAlias,
           taChannel.capacity,
           btcChannels,
           rebalanceSats
@@ -734,7 +734,7 @@ export class TradeResolver {
   ): Promise<
     Array<{
       scid: string;
-      peerAlias: string | undefined;
+      partnerScidAlias: string | undefined;
       capacity: number;
       localBalance: number;
       localReserve: number;
@@ -797,7 +797,7 @@ export class TradeResolver {
 
     const results: Array<{
       scid: string;
-      peerAlias: string | undefined;
+      partnerScidAlias: string | undefined;
       capacity: number;
       localBalance: number;
       localReserve: number;
@@ -822,7 +822,7 @@ export class TradeResolver {
           // look up the channel locally. The real SCID and our own aliases
           // (other_ids) are not in the peer's outgoing forwarding table for
           // private TA channels.
-          peerAlias: ch.partner_scid_alias,
+          partnerScidAlias: ch.partner_scid_alias,
           capacity: ch.capacity,
           localBalance: ch.local_balance,
           localReserve: ch.local_reserve,
@@ -842,7 +842,7 @@ export class TradeResolver {
     accountId: string,
     peerPubkey: string,
     taChannelScid: string,
-    taChannelPeerAlias: string | undefined,
+    taChannelPartnerScidAlias: string | undefined,
     taChannelCapacity: number,
     btcChannels: Array<BtcChannel>,
     rebalanceSats: number
@@ -956,7 +956,7 @@ export class TradeResolver {
           // the peer charges this fee for forwarding on their outgoing leg.
           // Use partner_scid_alias (the peer's own local alias) — the real SCID
           // and our own alias_scids give UnknownNextPeer for private TA channels.
-          channel: taChannelPeerAlias ?? taChannelScid,
+          channel: taChannelPartnerScidAlias ?? taChannelScid,
           channel_capacity: taChannelCapacity,
           fee: hop2Fee,
           fee_mtokens: String(hop2FeeMtokens),
@@ -975,7 +975,7 @@ export class TradeResolver {
 
     this.logger.info('Executing circular rebalance to top up TA channel', {
       taChannelScid,
-      taChannelPeerAlias,
+      taChannelPartnerScidAlias,
       btcChannelId: btcChannel.id,
       rebalanceSats,
       hop1Timeout,
@@ -1001,7 +1001,7 @@ export class TradeResolver {
 
     this.logger.info('Circular rebalance completed', {
       taChannelScid,
-      taChannelPeerAlias,
+      taChannelPartnerScidAlias,
       is_confirmed: rebalResult?.is_confirmed,
       hops: rebalResult?.hops?.map((h: { channel: string }) => h.channel),
     });

--- a/src/server/modules/api/trade/trade.resolver.ts
+++ b/src/server/modules/api/trade/trade.resolver.ts
@@ -27,10 +27,6 @@ const DEFAULT_INVOICE_EXPIRY_SEC = 30;
 // How much we overshoot the channel reserve requirement when rebalancing
 const SATS_RESERVE_BUFFER_PCT = 50;
 
-// Minimum local balance a TA channel needs to anchor an outgoing asset HTLC.
-// LND requires the local side to cover the commitment reserve AND have enough
-// to fund the anchor output for the HTLC. In practice this is ~1062 sats
-// (3 × dust_limit of 354 sats). We use a round number slightly above that.
 const DEFAULT_CHANNEL_CLTV_DELTA = 40; // LND default for channel forwarding policies
 // Deliberately small: this is a self-payment, settled within seconds. Must be
 // ≥ FinalCltvRejectDelta (19) so LND accepts the HTLC at the final hop. Must
@@ -664,10 +660,41 @@ export class TradeResolver {
       groupKey
     );
 
+    if (taChannels.length === 0) return;
+
+    // Fetch once — these don't change between iterations.
+    const [[heightResult, heightError], [identity, identityError]] =
+      await Promise.all([
+        toWithError(this.nodeService.getHeight(id)),
+        toWithError(this.nodeService.getIdentity(id)),
+      ]);
+
+    if (heightError || !heightResult?.current_block_height) {
+      this.logger.warn(
+        'ensureTaChannelSatReserve: could not get block height; skipping',
+        { error: heightError }
+      );
+      return;
+    }
+
+    if (identityError || !identity?.public_key) {
+      this.logger.warn(
+        'ensureTaChannelSatReserve: could not get identity; skipping',
+        { error: identityError }
+      );
+      return;
+    }
+
+    // Track consumed BTC balance across iterations so we don't overspend
+    // a channel that was already partially drained by a prior rebalance.
+    const btcBalanceConsumed = new Map<string, number>();
+
     for (const taChannel of taChannels) {
-      // Need enough local sats above the commitment reserve to transport the
-      // asset HTLC. SATS_RESERVE_BUFFER_PCT provides the headroom above this.
-      const minRequiredBalance = taChannel.localReserve + invoiceSats;
+      // Buffer only the reserve portion — invoiceSats is a fixed cost.
+      const bufferedReserve = Math.ceil(
+        taChannel.localReserve * (1 + SATS_RESERVE_BUFFER_PCT / 100)
+      );
+      const minRequiredBalance = bufferedReserve + invoiceSats;
 
       this.logger.info('ensureTaChannelSatReserve: channel balance check', {
         taChannelScid: taChannel.scid,
@@ -680,9 +707,31 @@ export class TradeResolver {
 
       if (taChannel.localBalance >= minRequiredBalance) continue;
 
-      const rebalanceSats =
-        Math.ceil(minRequiredBalance * (1 + SATS_RESERVE_BUFFER_PCT / 100)) -
-        taChannel.localBalance;
+      const rebalanceSats = minRequiredBalance - taChannel.localBalance;
+
+      // Pick the BTC channel with the most remaining local balance.
+      const btcChannel = [...btcChannels].sort((a, b) => {
+        const aRemaining =
+          a.local_balance - (btcBalanceConsumed.get(a.id) ?? 0);
+        const bRemaining =
+          b.local_balance - (btcBalanceConsumed.get(b.id) ?? 0);
+        return bRemaining - aRemaining;
+      })[0];
+
+      const consumed = btcBalanceConsumed.get(btcChannel.id) ?? 0;
+      const availableBalance = btcChannel.local_balance - consumed;
+
+      if (availableBalance < rebalanceSats) {
+        this.logger.warn(
+          'Insufficient remaining BTC balance for rebalance; skipping channel',
+          {
+            taChannelScid: taChannel.scid,
+            rebalanceSats,
+            availableBalance,
+          }
+        );
+        continue;
+      }
 
       this.logger.info(
         'TA channel below reserve; initiating circular rebalance',
@@ -702,8 +751,14 @@ export class TradeResolver {
           taChannel.scid,
           taChannel.partnerScidAlias,
           taChannel.capacity,
-          btcChannels,
-          rebalanceSats
+          btcChannel,
+          rebalanceSats,
+          heightResult.current_block_height,
+          identity.public_key
+        );
+        btcBalanceConsumed.set(
+          btcChannel.id,
+          (btcBalanceConsumed.get(btcChannel.id) ?? 0) + rebalanceSats
         );
       } catch (err: unknown) {
         this.logger.warn(
@@ -844,33 +899,16 @@ export class TradeResolver {
     taChannelScid: string,
     taChannelPartnerScidAlias: string | undefined,
     taChannelCapacity: number,
-    btcChannels: Array<BtcChannel>,
-    rebalanceSats: number
+    btcChannel: BtcChannel,
+    rebalanceSats: number,
+    currentHeight: number,
+    identityPubkey: string
   ): Promise<void> {
-    if (btcChannels.length === 0) {
-      throw new Error('No BTC channels available for circular rebalance');
-    }
-
-    const btcChannel = [...btcChannels].sort(
-      (a, b) => b.local_balance - a.local_balance
-    )[0];
-
-    if (btcChannel.local_balance < rebalanceSats) {
-      throw new Error(
-        `Insufficient BTC local balance for circular rebalance: ` +
-          `need ${rebalanceSats} sats, have ${btcChannel.local_balance} sats`
-      );
-    }
-
-    const [
-      [heightResult, heightError],
-      [identity, identityError],
-      [btcChannelInfo, btcChannelInfoError],
-    ] = await Promise.all([
-      toWithError(this.nodeService.getHeight(accountId)),
-      toWithError(this.nodeService.getIdentity(accountId)),
-      toWithError(this.nodeService.getChannel(accountId, btcChannel.id)),
-    ]);
+    const [[btcChannelInfo, btcChannelInfoError], [taChannelInfo]] =
+      await Promise.all([
+        toWithError(this.nodeService.getChannel(accountId, btcChannel.id)),
+        toWithError(this.nodeService.getChannel(accountId, taChannelScid)),
+      ]);
 
     if (btcChannelInfoError) {
       this.logger.warn(
@@ -879,29 +917,18 @@ export class TradeResolver {
       );
     }
 
-    if (heightError || !heightResult?.current_block_height) {
-      throw new Error('Rebalance failed: could not get current block height');
-    }
-
-    if (identityError || !identity?.public_key) {
-      throw new Error('Rebalance failed: could not get node identity');
-    }
-
     const btcPeerPolicy = btcChannelInfo?.policies?.find(
       (p: { public_key: string }) => p.public_key === peerPubkey
     );
     const btcChannelCltvDelta: number =
       btcPeerPolicy?.cltv_delta ?? DEFAULT_CHANNEL_CLTV_DELTA;
 
-    const [taChannelInfo] = await toWithError(
-      this.nodeService.getChannel(accountId, taChannelScid)
-    );
     const taOurPolicy = taChannelInfo?.policies?.find(
-      (p: { public_key: string }) => p.public_key === identity.public_key
+      (p: { public_key: string }) => p.public_key === identityPubkey
     );
     const taCltvDelta: number =
       taOurPolicy?.cltv_delta ?? DEFAULT_CHANNEL_CLTV_DELTA;
-    // Fee the peer charges on the TA channel (their outgoing leg for hop 2).
+    // Fee the peer charges on the TA channel (their outgoing leg).
     const taPeerPolicy = taChannelInfo?.policies?.find(
       (p: { public_key: string }) => p.public_key === peerPubkey
     );
@@ -921,48 +948,47 @@ export class TradeResolver {
       );
     }
 
-    const currentHeight: number = heightResult.current_block_height;
     const invoiceCltvDelta = DEFAULT_INVOICE_CLTV_DELTA;
     const hop2Timeout = currentHeight + invoiceCltvDelta + CLTV_BLOCK_BUFFER;
     const hopCltvDelta = Math.max(taCltvDelta, btcChannelCltvDelta);
     const hop1Timeout = hop2Timeout + hopCltvDelta;
 
     const forwardMtokens = BigInt(rebalanceSats) * BigInt(1000);
-    // Fee the peer earns forwarding on the TA channel (hop 2, their outgoing leg).
-    // Hop 1 (our BTC outgoing) has fee=0 — we don't pay ourselves to send.
-    const hop2FeeMtokens =
+    // Fee the peer earns forwarding on the TA channel (their outgoing leg).
+    // This goes on hop 1 (the intermediary); hop 2 (final destination) is fee=0.
+    const hop1FeeMtokens =
       taBaseFee + (forwardMtokens * taFeeRate) / BigInt(1_000_000);
-    const hop2Fee = Number((hop2FeeMtokens + BigInt(999)) / BigInt(1000));
-    const totalMtokens = forwardMtokens + hop2FeeMtokens;
+    const hop1Fee = Number((hop1FeeMtokens + BigInt(999)) / BigInt(1000));
+    const totalMtokens = forwardMtokens + hop1FeeMtokens;
 
     const rebalanceRoute = {
-      fee: hop2Fee,
-      fee_mtokens: String(hop2FeeMtokens),
+      fee: hop1Fee,
+      fee_mtokens: String(hop1FeeMtokens),
       hops: [
         {
-          // Hop 1: us → peer via BTC channel. Fee=0: we are the sender on our
-          // own channel and don't charge ourselves a forwarding fee.
+          // Hop 1: us → peer via BTC channel. The peer is the intermediary
+          // and charges a forwarding fee (based on TA channel policy, their
+          // outgoing leg).
           channel: btcChannel.id,
           channel_capacity: btcChannel.capacity,
-          fee: 0,
-          fee_mtokens: '0',
+          fee: hop1Fee,
+          fee_mtokens: String(hop1FeeMtokens),
           forward: rebalanceSats,
           forward_mtokens: String(forwardMtokens),
           public_key: peerPubkey,
           timeout: hop2Timeout,
         },
         {
-          // Hop 2: peer → us via TA channel. Fee = peer's TA channel policy:
-          // the peer charges this fee for forwarding on their outgoing leg.
+          // Hop 2: peer → us via TA channel (final destination, fee=0).
           // Use partner_scid_alias (the peer's own local alias) — the real SCID
           // and our own alias_scids give UnknownNextPeer for private TA channels.
           channel: taChannelPartnerScidAlias ?? taChannelScid,
           channel_capacity: taChannelCapacity,
-          fee: hop2Fee,
-          fee_mtokens: String(hop2FeeMtokens),
+          fee: 0,
+          fee_mtokens: '0',
           forward: rebalanceSats,
           forward_mtokens: String(forwardMtokens),
-          public_key: identity.public_key,
+          public_key: identityPubkey,
           timeout: hop2Timeout,
         },
       ],

--- a/src/server/modules/api/trade/trade.resolver.ts
+++ b/src/server/modules/api/trade/trade.resolver.ts
@@ -3,7 +3,7 @@ import { Inject } from '@nestjs/common';
 import { WINSTON_MODULE_PROVIDER } from 'nest-winston';
 import { Logger } from 'winston';
 import { GraphQLError } from 'graphql';
-import type { Route } from 'lightning';
+import type { PayViaRoutesResult, Route } from 'lightning';
 import { TapdNodeService } from '../../node/tapd/tapd-node.service';
 import { NodeService } from '../../node/node.service';
 import { CurrentUser } from '../../security/security.decorators';
@@ -15,11 +15,37 @@ import {
   TradeQuoteResult,
   ExecuteTradeInput,
   ExecuteTradeResult,
+  BtcChannel,
+  TaChannel,
+  TaChannelPointAndId,
 } from './trade.types';
 
 const HEX_PUBKEY_RE = /^[0-9a-f]{66}$/;
 const HEX_ASSET_ID_RE = /^[0-9a-f]{64}$/;
 const DEFAULT_INVOICE_EXPIRY_SEC = 30;
+
+// How much we overshoot the channel reserve requirement when rebalancing
+const SATS_RESERVE_BUFFER_PCT = 50;
+
+// Minimum local balance a TA channel needs to anchor an outgoing asset HTLC.
+// LND requires the local side to cover the commitment reserve AND have enough
+// to fund the anchor output for the HTLC. In practice this is ~1062 sats
+// (3 × dust_limit of 354 sats). We use a round number slightly above that.
+const DEFAULT_CHANNEL_CLTV_DELTA = 40; // LND default for channel forwarding policies
+// Deliberately small: this is a self-payment, settled within seconds. Must be
+// ≥ FinalCltvRejectDelta (19) so LND accepts the HTLC at the final hop. Must
+// match the cltv_delta passed to createInvoice so the route satisfies the
+// invoice's min_final_cltv_expiry.
+const DEFAULT_INVOICE_CLTV_DELTA = 24;
+
+// Extra blocks added to final CLTV to tolerate a block arriving between
+// getHeight and HTLC settlement.
+const CLTV_BLOCK_BUFFER = 3;
+
+// The `lightning` package intentionally leaves SIMPLE_TAPROOT_OVERLAY unmapped,
+// so TA channels have type === undefined while all BTC channel types are strings.
+const isTaChannel = (ch: { type?: string }) => !ch.type;
+const isBtcChannel = (ch: { type?: string }) => !!ch.type;
 
 @Resolver()
 export class TradeResolver {
@@ -137,19 +163,19 @@ export class TradeResolver {
     };
   }
 
-  // ── Sell (SALE) ──
-  // Uses addAssetSellOrder to get an explicit RFQ quote. The rfqId must be
-  // passed back at execute time to bind sendAssetPayment to this rate.
-
+  /**
+   * Uses addAssetSellOrder to get an explicit RFQ quote. The rfqId must be
+   * passed back at execute time to bind sendAssetPayment to this rate.
+   */
   private async getSellQuote(
-    id: string,
+    accountId: string,
     input: TradeQuoteInput
   ): Promise<TradeQuoteResult> {
     const paymentMaxAmtMsat = String(BigInt(100_000_000_000));
 
     const [quote, error] = await toWithError(
       this.tapdNodeService.getSellQuote({
-        id,
+        id: accountId,
         assetId: input.tapdAssetId || undefined,
         groupKey: input.tapdGroupKey || undefined,
         paymentMaxAmtMsat,
@@ -260,7 +286,8 @@ export class TradeResolver {
 
     if (btcChannel.local_balance < decoded.tokens) {
       throw new GraphQLError(
-        `Insufficient outbound BTC liquidity with trade partner: need ${decoded.tokens} sats, have ${btcChannel.local_balance} sats`
+        `Insufficient outbound BTC liquidity with trade partner: ` +
+          `need ${decoded.tokens} sats, have ${btcChannel.local_balance} sats`
       );
     }
 
@@ -294,15 +321,15 @@ export class TradeResolver {
     );
 
     const currentHeight: number = heightResult.current_block_height;
-    const invoiceCltvDelta = decoded.cltv_delta ?? 40;
+    const invoiceCltvDelta = decoded.cltv_delta ?? DEFAULT_INVOICE_CLTV_DELTA;
     const hintCltvDelta = routeHint.cltv_delta ?? 144;
-    const btcChannelCltvDelta: number = peerPolicy?.cltv_delta ?? 40;
+    const btcChannelCltvDelta: number =
+      peerPolicy?.cltv_delta ?? DEFAULT_CHANNEL_CLTV_DELTA;
 
-    // +3 block buffer on final CLTV to tolerate a block arriving between
-    // getHeight and HTLC settlement. Use the larger of the virtual SCID's
-    // cltv_delta and the BTC channel's cltv_delta for the hop delta — the
-    // peer may enforce its BTC channel policy on forwards.
-    const hop2Timeout = currentHeight + invoiceCltvDelta + 3;
+    // Use the larger of the virtual SCID's cltv_delta and the BTC channel's
+    // cltv_delta for the hop delta — the peer may enforce its BTC channel
+    // policy on forwards.
+    const hop2Timeout = currentHeight + invoiceCltvDelta + CLTV_BLOCK_BUFFER;
     const hopCltvDelta = Math.max(hintCltvDelta, btcChannelCltvDelta);
     const hop1Timeout = hop2Timeout + hopCltvDelta;
 
@@ -463,6 +490,15 @@ export class TradeResolver {
       );
     }
 
+    await this.ensureTaChannelSatReserve(
+      id,
+      input.peerPubkey,
+      input.tapdAssetId || undefined,
+      input.tapdGroupKey || undefined,
+      btcChannels,
+      invoiceSats
+    );
+
     // Self-payment loop: assets leave via the TA channel (forced first hop by
     // tapd/RFQ) and the sats return leg comes back via the BTC channel. Build
     // an explicit BTC-only route hint so pathfinding only sees the valid return
@@ -490,6 +526,8 @@ export class TradeResolver {
     this.logger.info('Executing sell trade', {
       assetAmount: input.assetAmount,
       invoiceSats,
+      tapdAssetId: input.tapdAssetId,
+      tapdGroupKey: input.tapdGroupKey,
       quote,
     });
 
@@ -537,12 +575,7 @@ export class TradeResolver {
   private async buildBtcReturnHint(
     id: string,
     peerPubkey: string,
-    btcChannels: Array<{
-      id: string;
-      capacity: number;
-      local_balance: number;
-      remote_balance: number;
-    }>
+    btcChannels: Array<BtcChannel>
   ): Promise<Route | undefined> {
     const sorted = [...btcChannels].sort(
       (a, b) => b.remote_balance - a.remote_balance
@@ -586,24 +619,396 @@ export class TradeResolver {
         channel: btcChannel.id,
         base_fee_mtokens: peerPolicy?.base_fee_mtokens ?? '1000',
         fee_rate: peerPolicy?.fee_rate ?? 2500, // parts per million
-        cltv_delta: peerPolicy?.cltv_delta ?? 40,
+        cltv_delta: peerPolicy?.cltv_delta ?? DEFAULT_CHANNEL_CLTV_DELTA,
       },
     ];
   }
 
-  // Filters by truthy `type` — SIMPLE_TAPROOT_OVERLAY stays undefined in the
-  // `lightning` package, so TA channels are excluded while BTC channels pass.
+  /**
+   * The TA channel must hold local_balance >= local_reserve in sats for LND to
+   * anchor the asset HTLC. If it doesn't, we circular-rebalance sats from the
+   * BTC channel into the TA channel before the sale.
+   *
+   * When there are multiple TA channels with the same peer and asset (e.g. two
+   * channels opened with the same edge node), LND's router selects the outgoing
+   * channel independently of our earlier pick. We therefore rebalance ALL
+   * matching channels that are below reserve so whichever one LND picks is
+   * already funded. Best-effort: a single failure is logged as a warning and
+   * the sell proceeds regardless.
+   */
+  private async ensureTaChannelSatReserve(
+    id: string,
+    peerPubkey: string,
+    assetId: string | undefined,
+    groupKey: string | undefined,
+    btcChannels: Array<BtcChannel>,
+    invoiceSats: number
+  ): Promise<void> {
+    this.logger.info('ensureTaChannelSatReserve: called', {
+      assetId,
+      groupKey,
+      peerPubkey,
+      invoiceSats,
+    });
+
+    const taChannels = await this.findTaChannelsForAsset(
+      id,
+      peerPubkey,
+      assetId,
+      groupKey
+    );
+
+    for (const taChannel of taChannels) {
+      // Need enough local sats above the commitment reserve to transport the
+      // asset HTLC. SATS_RESERVE_BUFFER_PCT provides the headroom above this.
+      const effectiveReserve = taChannel.localReserve + invoiceSats;
+
+      this.logger.info('ensureTaChannelSatReserve: channel balance check', {
+        taChannelScid: taChannel.scid,
+        localBalance: taChannel.localBalance,
+        localReserve: taChannel.localReserve,
+        invoiceSats,
+        effectiveReserve,
+        needsRebalance: taChannel.localBalance < effectiveReserve,
+      });
+
+      if (taChannel.localBalance >= effectiveReserve) continue;
+
+      const rebalanceSats =
+        Math.ceil(effectiveReserve * (1 + SATS_RESERVE_BUFFER_PCT / 100)) -
+        taChannel.localBalance;
+
+      this.logger.info(
+        'TA channel below reserve; initiating circular rebalance',
+        {
+          taChannelScid: taChannel.scid,
+          localBalance: taChannel.localBalance,
+          localReserve: taChannel.localReserve,
+          effectiveReserve,
+          rebalanceSats,
+        }
+      );
+
+      try {
+        await this.rebalanceTaChannel(
+          id,
+          peerPubkey,
+          taChannel.scid,
+          taChannel.peerAlias,
+          taChannel.capacity,
+          btcChannels,
+          rebalanceSats
+        );
+      } catch (err: unknown) {
+        this.logger.warn(
+          'Circular rebalance failed; attempting sell trade anyway',
+          {
+            taChannelScid: taChannel.scid,
+            error: err instanceof Error ? err.message : String(err),
+          }
+        );
+      }
+    }
+  }
+
+  /**
+   * Finds ALL TA channels for the given asset and peer, joining LND's BTC-layer
+   * channel data (SCID, local_reserve) with tapd's asset-layer data (assetId,
+   * groupKey) via the channelPoint key (txid:vout).
+   *
+   * Returns all matching channels because when multiple TA channels exist with
+   * the same peer, LND's router selects the outgoing channel independently —
+   * we need all candidates so we can ensure each one meets its reserve.
+   */
+  private async findTaChannelsForAsset(
+    accountId: string,
+    peerPubkey: string,
+    assetId: string | undefined,
+    groupKey: string | undefined
+  ): Promise<
+    Array<{
+      scid: string;
+      peerAlias: string | undefined;
+      capacity: number;
+      localBalance: number;
+      localReserve: number;
+    }>
+  > {
+    if (!assetId && !groupKey) {
+      this.logger.error(
+        'findTaChannelsForAsset: neither assetId nor groupKey provided',
+        { assetId, groupKey }
+      );
+      return [];
+    }
+
+    const [channelsResult, channelsError] = await toWithError(
+      this.nodeService.getChannels(accountId, {
+        partner_public_key: peerPubkey,
+        is_active: true,
+      })
+    );
+
+    if (channelsError) {
+      this.logger.warn('Failed to fetch TA channel info with peer', {
+        error: channelsError,
+        peerPubkey,
+      });
+      return [];
+    }
+
+    if (!channelsResult?.channels?.length) return [];
+
+    // Get satoshi-level channel data for TA channels
+    const satLayerTaChannels = channelsResult.channels.filter(
+      isTaChannel
+    ) as Array<TaChannel>;
+
+    if (satLayerTaChannels.length === 0) return [];
+
+    // Get asset-level channel data for TA channels
+    const [assetLayerTaChannels, assetError] = await toWithError(
+      this.tapdNodeService.getAssetChannelBalances({
+        id: accountId,
+        peerPubkey,
+      })
+    );
+
+    if (assetError || !assetLayerTaChannels) {
+      this.logger.warn('Failed to fetch asset channel balances with peer', {
+        error: assetError,
+        peerPubkey,
+      });
+      return [];
+    }
+
+    const assetLayerByChannelPoint = new Map<string, TaChannelPointAndId>(
+      assetLayerTaChannels.map((ac: TaChannelPointAndId) => [
+        ac.channelPoint,
+        ac,
+      ])
+    );
+
+    const results: Array<{
+      scid: string;
+      peerAlias: string | undefined;
+      capacity: number;
+      localBalance: number;
+      localReserve: number;
+    }> = [];
+
+    for (const ch of satLayerTaChannels) {
+      const channelPoint = `${ch.transaction_id}:${ch.transaction_vout}`;
+      const assetInfo = assetLayerByChannelPoint.get(channelPoint);
+
+      if (!assetInfo) continue;
+
+      const matches = groupKey
+        ? assetInfo.groupKey === groupKey
+        : assetInfo.assetId === assetId;
+
+      if (matches) {
+        results.push({
+          scid: ch.id,
+          // partner_scid_alias is the alias the peer assigned to their side
+          // of this channel — the ID in their own forwarding table. Use it
+          // for hop 2 of the circular rebalance (peer → us) so the peer can
+          // look up the channel locally. The real SCID and our own aliases
+          // (other_ids) are not in the peer's outgoing forwarding table for
+          // private TA channels.
+          peerAlias: ch.partner_scid_alias,
+          capacity: ch.capacity,
+          localBalance: ch.local_balance,
+          localReserve: ch.local_reserve,
+        });
+      }
+    }
+
+    return results;
+  }
+
+  /**
+   * Circular-rebalances the TA channel by sending a sats-only self-payment:
+   * sats exit via the BTC channel and re-enter via the TA channel, topping up
+   * the TA channel's sat balance above the reserve requirement.
+   */
+  private async rebalanceTaChannel(
+    id: string,
+    peerPubkey: string,
+    taChannelScid: string,
+    taChannelPeerAlias: string | undefined,
+    taChannelCapacity: number,
+    btcChannels: Array<BtcChannel>,
+    rebalanceSats: number
+  ): Promise<void> {
+    if (btcChannels.length === 0) {
+      throw new Error('No BTC channels available for circular rebalance');
+    }
+
+    const btcChannel = [...btcChannels].sort(
+      (a, b) => b.local_balance - a.local_balance
+    )[0];
+
+    if (btcChannel.local_balance < rebalanceSats) {
+      throw new Error(
+        `Insufficient BTC local balance for circular rebalance: ` +
+          `need ${rebalanceSats} sats, have ${btcChannel.local_balance} sats`
+      );
+    }
+
+    const [
+      [heightResult, heightError],
+      [identity, identityError],
+      [btcChannelInfo, btcChannelInfoError],
+    ] = await Promise.all([
+      toWithError(this.nodeService.getHeight(id)),
+      toWithError(this.nodeService.getIdentity(id)),
+      toWithError(this.nodeService.getChannel(id, btcChannel.id)),
+    ]);
+
+    if (btcChannelInfoError) {
+      this.logger.warn(
+        'rebalanceTaChannel: could not fetch BTC channel info; using fee defaults',
+        { error: btcChannelInfoError, channelId: btcChannel.id }
+      );
+    }
+
+    if (heightError || !heightResult?.current_block_height) {
+      throw new Error('Rebalance failed: could not get current block height');
+    }
+
+    if (identityError || !identity?.public_key) {
+      throw new Error('Rebalance failed: could not get node identity');
+    }
+
+    const btcPeerPolicy = btcChannelInfo?.policies?.find(
+      (p: { public_key: string }) => p.public_key === peerPubkey
+    );
+    const btcChannelCltvDelta: number =
+      btcPeerPolicy?.cltv_delta ?? DEFAULT_CHANNEL_CLTV_DELTA;
+
+    const [taChannelInfo] = await toWithError(
+      this.nodeService.getChannel(id, taChannelScid)
+    );
+    const taOurPolicy = taChannelInfo?.policies?.find(
+      (p: { public_key: string }) => p.public_key === identity.public_key
+    );
+    const taCltvDelta: number =
+      taOurPolicy?.cltv_delta ?? DEFAULT_CHANNEL_CLTV_DELTA;
+    // Fee the peer charges on the TA channel (their outgoing leg for hop 2).
+    const taPeerPolicy = taChannelInfo?.policies?.find(
+      (p: { public_key: string }) => p.public_key === peerPubkey
+    );
+    const taBaseFee = BigInt(taPeerPolicy?.base_fee_mtokens ?? '1000');
+    const taFeeRate = BigInt(taPeerPolicy?.fee_rate ?? 2500);
+
+    const [invoice, invoiceError] = await toWithError(
+      this.nodeService.createInvoice(id, {
+        tokens: rebalanceSats,
+        cltv_delta: DEFAULT_INVOICE_CLTV_DELTA,
+      })
+    );
+
+    if (invoiceError || !invoice?.request || !invoice.id || !invoice.payment) {
+      throw new Error(
+        'Rebalance failed: could not create self-payment invoice'
+      );
+    }
+
+    const currentHeight: number = heightResult.current_block_height;
+    const invoiceCltvDelta = DEFAULT_INVOICE_CLTV_DELTA;
+    const hop2Timeout = currentHeight + invoiceCltvDelta + CLTV_BLOCK_BUFFER;
+    const hopCltvDelta = Math.max(taCltvDelta, btcChannelCltvDelta);
+    const hop1Timeout = hop2Timeout + hopCltvDelta;
+
+    const forwardMtokens = BigInt(rebalanceSats) * BigInt(1000);
+    // Fee the peer earns forwarding on the TA channel (hop 2, their outgoing leg).
+    // Hop 1 (our BTC outgoing) has fee=0 — we don't pay ourselves to send.
+    const hop2FeeMtokens =
+      taBaseFee + (forwardMtokens * taFeeRate) / BigInt(1_000_000);
+    const hop2Fee = Number((hop2FeeMtokens + BigInt(999)) / BigInt(1000));
+    const totalMtokens = forwardMtokens + hop2FeeMtokens;
+
+    const rebalanceRoute = {
+      fee: hop2Fee,
+      fee_mtokens: String(hop2FeeMtokens),
+      hops: [
+        {
+          // Hop 1: us → peer via BTC channel. Fee=0: we are the sender on our
+          // own channel and don't charge ourselves a forwarding fee.
+          channel: btcChannel.id,
+          channel_capacity: btcChannel.capacity,
+          fee: 0,
+          fee_mtokens: '0',
+          forward: rebalanceSats,
+          forward_mtokens: String(forwardMtokens),
+          public_key: peerPubkey,
+          timeout: hop2Timeout,
+        },
+        {
+          // Hop 2: peer → us via TA channel. Fee = peer's TA channel policy:
+          // the peer charges this fee for forwarding on their outgoing leg.
+          // Use partner_scid_alias (the peer's own local alias) — the real SCID
+          // and our own alias_scids give UnknownNextPeer for private TA channels.
+          channel: taChannelPeerAlias ?? taChannelScid,
+          channel_capacity: taChannelCapacity,
+          fee: hop2Fee,
+          fee_mtokens: String(hop2FeeMtokens),
+          forward: rebalanceSats,
+          forward_mtokens: String(forwardMtokens),
+          public_key: identity.public_key,
+          timeout: hop2Timeout,
+        },
+      ],
+      mtokens: String(totalMtokens),
+      payment: invoice.payment,
+      timeout: hop1Timeout,
+      tokens: Number((totalMtokens + BigInt(999)) / BigInt(1000)),
+      total_mtokens: String(forwardMtokens),
+    };
+
+    this.logger.info('Executing circular rebalance to top up TA channel', {
+      taChannelScid,
+      taChannelPeerAlias,
+      btcChannelId: btcChannel.id,
+      rebalanceSats,
+      hop1Timeout,
+      hop2Timeout,
+      hopCltvDelta,
+    });
+
+    let rebalResult: PayViaRoutesResult | undefined;
+    try {
+      rebalResult = await this.nodeService.payViaRoutes(id, {
+        id: invoice.id,
+        routes: [rebalanceRoute],
+      });
+    } catch (err: unknown) {
+      const rawErr = err as unknown[];
+      this.logger.error('Circular rebalance payment failed', {
+        error: Array.isArray(rawErr) ? rawErr[1] : String(err),
+        failures: JSON.stringify(Array.isArray(rawErr) ? rawErr[2] : undefined),
+        taChannelScid,
+      });
+      throw new Error('Circular rebalance payment failed');
+    }
+
+    this.logger.info('Circular rebalance completed', {
+      taChannelScid,
+      taChannelPeerAlias,
+      is_confirmed: rebalResult?.is_confirmed,
+      hops: rebalResult?.hops?.map((h: { channel: string }) => h.channel),
+    });
+
+    if (!rebalResult?.is_confirmed) {
+      throw new Error('Circular rebalance payment did not confirm');
+    }
+  }
+
   private async getBtcChannelsWithPeer(
     id: string,
     peerPubkey: string
-  ): Promise<
-    Array<{
-      id: string;
-      capacity: number;
-      local_balance: number;
-      remote_balance: number;
-    }>
-  > {
+  ): Promise<Array<BtcChannel>> {
     const [channelsResult, channelsError] = await toWithError(
       this.nodeService.getChannels(id, {
         partner_public_key: peerPubkey,
@@ -622,14 +1027,7 @@ export class TradeResolver {
       return [];
     }
 
-    return channelsResult.channels.filter(
-      (ch: { type?: string }) => !!ch.type
-    ) as Array<{
-      id: string;
-      capacity: number;
-      local_balance: number;
-      remote_balance: number;
-    }>;
+    return channelsResult.channels.filter(isBtcChannel) as Array<BtcChannel>;
   }
 
   /**

--- a/src/server/modules/api/trade/trade.resolver.ts
+++ b/src/server/modules/api/trade/trade.resolver.ts
@@ -217,7 +217,7 @@ export class TradeResolver {
   }
 
   private async executePurchase(
-    id: string,
+    accountId: string,
     input: ExecuteTradeInput
   ): Promise<ExecuteTradeResult> {
     const { paymentRequest } = input;
@@ -229,7 +229,7 @@ export class TradeResolver {
     }
 
     const [decoded, decodeError] = await toWithError(
-      this.nodeService.decodePaymentRequest(id, paymentRequest)
+      this.nodeService.decodePaymentRequest(accountId, paymentRequest)
     );
 
     if (decodeError || decoded?.tokens == null) {
@@ -272,7 +272,10 @@ export class TradeResolver {
       cltvDelta: routeHint.cltv_delta,
     });
 
-    const btcChannels = await this.getBtcChannelsWithPeer(id, input.peerPubkey);
+    const btcChannels = await this.getBtcChannelsWithPeer(
+      accountId,
+      input.peerPubkey
+    );
 
     if (btcChannels.length === 0) {
       throw new GraphQLError(
@@ -296,9 +299,9 @@ export class TradeResolver {
       [identity, identityError],
       [channelInfo, channelInfoError],
     ] = await Promise.all([
-      toWithError(this.nodeService.getHeight(id)),
-      toWithError(this.nodeService.getIdentity(id)),
-      toWithError(this.nodeService.getChannel(id, btcChannel.id)),
+      toWithError(this.nodeService.getHeight(accountId)),
+      toWithError(this.nodeService.getIdentity(accountId)),
+      toWithError(this.nodeService.getChannel(accountId, btcChannel.id)),
     ]);
 
     if (channelInfoError) {
@@ -396,7 +399,7 @@ export class TradeResolver {
       | undefined;
 
     try {
-      payResult = await this.nodeService.payViaRoutes(id, {
+      payResult = await this.nodeService.payViaRoutes(accountId, {
         id: decoded.id,
         routes: [route],
       });
@@ -430,7 +433,7 @@ export class TradeResolver {
   }
 
   private async executeSale(
-    id: string,
+    accountId: string,
     input: ExecuteTradeInput
   ): Promise<ExecuteTradeResult> {
     const { rfqId } = input;
@@ -444,7 +447,7 @@ export class TradeResolver {
     // Re-derive satsAmount server-side from the accepted quote instead of
     // trusting the client-provided value.
     const [quote, quoteError] = await toWithError(
-      this.tapdNodeService.queryAcceptedSellQuote({ id, rfqId })
+      this.tapdNodeService.queryAcceptedSellQuote({ id: accountId, rfqId })
     );
 
     if (quoteError || !quote) {
@@ -473,7 +476,10 @@ export class TradeResolver {
     }
 
     // Fetch BTC channels once for both the return-hint and the liquidity check.
-    const btcChannels = await this.getBtcChannelsWithPeer(id, input.peerPubkey);
+    const btcChannels = await this.getBtcChannelsWithPeer(
+      accountId,
+      input.peerPubkey
+    );
     if (btcChannels.length === 0) {
       throw new GraphQLError(
         'No active BTC channel with trade partner — cannot execute trade'
@@ -491,7 +497,7 @@ export class TradeResolver {
     }
 
     await this.ensureTaChannelSatReserve(
-      id,
+      accountId,
       input.peerPubkey,
       input.tapdAssetId || undefined,
       input.tapdGroupKey || undefined,
@@ -504,13 +510,13 @@ export class TradeResolver {
     // an explicit BTC-only route hint so pathfinding only sees the valid return
     // path — omitting TA channels prevents "same incoming and outgoing channel".
     const btcHopHint = await this.buildBtcReturnHint(
-      id,
+      accountId,
       input.peerPubkey,
       btcChannels
     );
 
     const [invoice, invoiceError] = await toWithError(
-      this.nodeService.createInvoice(id, {
+      this.nodeService.createInvoice(accountId, {
         tokens: invoiceSats,
         routes: btcHopHint ? [btcHopHint] : undefined,
       })
@@ -533,7 +539,7 @@ export class TradeResolver {
 
     const [payResult, payError] = await toWithError(
       this.tapdNodeService.sendAssetPayment({
-        id,
+        id: accountId,
         assetId: input.tapdAssetId || undefined,
         groupKey: input.tapdGroupKey || undefined,
         assetAmount: input.assetAmount,
@@ -833,7 +839,7 @@ export class TradeResolver {
    * the TA channel's sat balance above the reserve requirement.
    */
   private async rebalanceTaChannel(
-    id: string,
+    accountId: string,
     peerPubkey: string,
     taChannelScid: string,
     taChannelPeerAlias: string | undefined,
@@ -861,9 +867,9 @@ export class TradeResolver {
       [identity, identityError],
       [btcChannelInfo, btcChannelInfoError],
     ] = await Promise.all([
-      toWithError(this.nodeService.getHeight(id)),
-      toWithError(this.nodeService.getIdentity(id)),
-      toWithError(this.nodeService.getChannel(id, btcChannel.id)),
+      toWithError(this.nodeService.getHeight(accountId)),
+      toWithError(this.nodeService.getIdentity(accountId)),
+      toWithError(this.nodeService.getChannel(accountId, btcChannel.id)),
     ]);
 
     if (btcChannelInfoError) {
@@ -888,7 +894,7 @@ export class TradeResolver {
       btcPeerPolicy?.cltv_delta ?? DEFAULT_CHANNEL_CLTV_DELTA;
 
     const [taChannelInfo] = await toWithError(
-      this.nodeService.getChannel(id, taChannelScid)
+      this.nodeService.getChannel(accountId, taChannelScid)
     );
     const taOurPolicy = taChannelInfo?.policies?.find(
       (p: { public_key: string }) => p.public_key === identity.public_key
@@ -903,7 +909,7 @@ export class TradeResolver {
     const taFeeRate = BigInt(taPeerPolicy?.fee_rate ?? 2500);
 
     const [invoice, invoiceError] = await toWithError(
-      this.nodeService.createInvoice(id, {
+      this.nodeService.createInvoice(accountId, {
         tokens: rebalanceSats,
         cltv_delta: DEFAULT_INVOICE_CLTV_DELTA,
       })
@@ -979,7 +985,7 @@ export class TradeResolver {
 
     let rebalResult: PayViaRoutesResult | undefined;
     try {
-      rebalResult = await this.nodeService.payViaRoutes(id, {
+      rebalResult = await this.nodeService.payViaRoutes(accountId, {
         id: invoice.id,
         routes: [rebalanceRoute],
       });

--- a/src/server/modules/api/trade/trade.types.ts
+++ b/src/server/modules/api/trade/trade.types.ts
@@ -97,7 +97,6 @@ export type BtcChannel = {
 
 export type TaChannel = BtcChannel & {
   local_reserve: number;
-  other_ids: string[];
   partner_scid_alias?: string;
   transaction_id: string;
   transaction_vout: number;

--- a/src/server/modules/api/trade/trade.types.ts
+++ b/src/server/modules/api/trade/trade.types.ts
@@ -87,3 +87,24 @@ export class ExecuteTradeResult {
   @Field({ nullable: true })
   feeSats?: string;
 }
+
+export type BtcChannel = {
+  id: string;
+  capacity: number;
+  local_balance: number;
+  remote_balance: number;
+};
+
+export type TaChannel = BtcChannel & {
+  local_reserve: number;
+  other_ids: string[];
+  partner_scid_alias?: string;
+  transaction_id: string;
+  transaction_vout: number;
+};
+
+export type TaChannelPointAndId = {
+  channelPoint: string;
+  assetId: string;
+  groupKey: string;
+};

--- a/src/server/modules/node/lightning.types.ts
+++ b/src/server/modules/node/lightning.types.ts
@@ -84,6 +84,7 @@ export type PayOptions = {
 
 export type CreateInvoiceOptions = {
   tokens?: number;
+  cltv_delta?: number;
   description?: string;
   description_hash?: string;
   expires_at?: string;


### PR DESCRIPTION
Before executing a sell trade, check whether the TA channel's local sat balance is below its reserve requirement. If so, run a circular rebalance: pay a sats invoice to ourselves routing out through the BTC channel and back in through the TA channel, topping up the sat balance with a 50% buffer above the bare deficit so the asset HTLC anchor can proceed.

Adds findTaChannelForAsset (joins LND channel data with tapd asset data via channelPoint) and rebalanceTaChannel (explicit 2-hop payViaRoutes), plus 16 new unit tests covering happy path, CLTV fallback math, and all error cases.