### PR TITLE
[AMB-2540] feat: enable automatic channel setup for SALE

### DIFF
--- a/schema.gql
+++ b/schema.gql
@@ -562,7 +562,7 @@ type Mutation {
   removePeer(publicKey: String): Boolean!
   removeTwofaSecret(token: String!): Boolean!
   sendToAddress(address: String!, fee: Float, sendAll: Boolean, target: Float, tokens: Float): ChainAddressSend!
-  setupTradePartner(input: SetupTradePartnerInput!): SetupTradePartnerResult!
+  setupTradeCapacity(input: SetupTradeCapacityInput!): SetupTradeCapacityResult!
   taproot_assets: TaprootAssetsMutations!
   team: TeamMutations!
   toggleConfig(field: ConfigFields!): Boolean!
@@ -671,6 +671,8 @@ type OfferReadinessResult {
   btc_channels: ChannelSummary!
   has_pending_order: Boolean!
   is_peer_connected: Boolean!
+  onchain_asset_balance: String!
+  onchain_balance_sats: String!
 }
 
 type OnChainBalance {
@@ -914,7 +916,7 @@ type SessionInfo {
   type: String
 }
 
-input SetupTradePartnerInput {
+input SetupTradeCapacityInput {
   ambossAssetId: String!
   assetAmount: String!
   assetRate: String!
@@ -928,7 +930,7 @@ input SetupTradePartnerInput {
   transactionType: TapTransactionType!
 }
 
-type SetupTradePartnerResult {
+type SetupTradeCapacityResult {
   magmaOrderAmountAsset: String
   magmaOrderAmountSats: String
   magmaOrderFeeSats: String
@@ -936,6 +938,8 @@ type SetupTradePartnerResult {
   magmaOrderStatus: String
   outboundChannelOutputIndex: Int
   outboundChannelTxid: String
+  skippedMagmaOrder: Boolean
+  skippedOutboundChannel: Boolean
   success: Boolean!
 }
 

--- a/schema.gql
+++ b/schema.gql
@@ -562,7 +562,7 @@ type Mutation {
   removePeer(publicKey: String): Boolean!
   removeTwofaSecret(token: String!): Boolean!
   sendToAddress(address: String!, fee: Float, sendAll: Boolean, target: Float, tokens: Float): ChainAddressSend!
-  setupTradeCapacity(input: SetupTradeCapacityInput!): SetupTradeCapacityResult!
+  setupTradePartner(input: SetupTradePartnerInput!): SetupTradePartnerResult!
   taproot_assets: TaprootAssetsMutations!
   team: TeamMutations!
   toggleConfig(field: ConfigFields!): Boolean!
@@ -671,8 +671,6 @@ type OfferReadinessResult {
   btc_channels: ChannelSummary!
   has_pending_order: Boolean!
   is_peer_connected: Boolean!
-  onchain_asset_balance: String!
-  onchain_balance_sats: String!
 }
 
 type OnChainBalance {
@@ -916,11 +914,12 @@ type SessionInfo {
   type: String
 }
 
-input SetupTradeCapacityInput {
+input SetupTradePartnerInput {
   ambossAssetId: String!
   assetAmount: String!
   assetRate: String!
   magmaOfferId: String!
+  openAssetChannel: Boolean
   satsAmount: String
   swapNodePubkey: String!
   swapNodeSockets: [String!]
@@ -929,7 +928,7 @@ input SetupTradeCapacityInput {
   transactionType: TapTransactionType!
 }
 
-type SetupTradeCapacityResult {
+type SetupTradePartnerResult {
   magmaOrderAmountAsset: String
   magmaOrderAmountSats: String
   magmaOrderFeeSats: String
@@ -937,8 +936,6 @@ type SetupTradeCapacityResult {
   magmaOrderStatus: String
   outboundChannelOutputIndex: Int
   outboundChannelTxid: String
-  skippedMagmaOrder: Boolean
-  skippedOutboundChannel: Boolean
   success: Boolean!
 }
 

--- a/schema.gql
+++ b/schema.gql
@@ -938,7 +938,7 @@ input SetupTradeCapacityInput {
   assetAmount: String!
   assetRate: String!
   magmaOfferId: String!
-  openAssetChannel: Boolean
+  openOutboundAssetChannel: Boolean
   satsAmount: String
   swapNodePubkey: String!
   swapNodeSockets: [String!]

--- a/schema.gql
+++ b/schema.gql
@@ -574,7 +574,7 @@ type Mutation {
   removePeer(publicKey: String): Boolean!
   removeTwofaSecret(token: String!): Boolean!
   sendToAddress(address: String!, fee: Float, sendAll: Boolean, target: Float, tokens: Float): ChainAddressSend!
-  setupTradePartner(input: SetupTradePartnerInput!): SetupTradePartnerResult!
+  setupTradeCapacity(input: SetupTradeCapacityInput!): SetupTradeCapacityResult!
   taproot_assets: TaprootAssetsMutations!
   team: TeamMutations!
   toggleConfig(field: ConfigFields!): Boolean!
@@ -688,6 +688,8 @@ type OfferReadinessResult {
   btc_channels: ChannelSummary!
   has_pending_order: Boolean!
   is_peer_connected: Boolean!
+  onchain_asset_balance: String!
+  onchain_balance_sats: String!
 }
 
 type OnChainBalance {
@@ -931,7 +933,7 @@ type SessionInfo {
   type: String
 }
 
-input SetupTradePartnerInput {
+input SetupTradeCapacityInput {
   ambossAssetId: String!
   assetAmount: String!
   assetRate: String!
@@ -945,7 +947,7 @@ input SetupTradePartnerInput {
   transactionType: TapTransactionType!
 }
 
-type SetupTradePartnerResult {
+type SetupTradeCapacityResult {
   magmaOrderAmountAsset: String
   magmaOrderAmountSats: String
   magmaOrderFeeSats: String
@@ -953,6 +955,8 @@ type SetupTradePartnerResult {
   magmaOrderStatus: String
   outboundChannelOutputIndex: Int
   outboundChannelTxid: String
+  skippedMagmaOrder: Boolean
+  skippedOutboundChannel: Boolean
   success: Boolean!
 }
 

--- a/schema.gql
+++ b/schema.gql
@@ -574,7 +574,7 @@ type Mutation {
   removePeer(publicKey: String): Boolean!
   removeTwofaSecret(token: String!): Boolean!
   sendToAddress(address: String!, fee: Float, sendAll: Boolean, target: Float, tokens: Float): ChainAddressSend!
-  setupTradeCapacity(input: SetupTradeCapacityInput!): SetupTradeCapacityResult!
+  setupTradePartner(input: SetupTradePartnerInput!): SetupTradePartnerResult!
   taproot_assets: TaprootAssetsMutations!
   team: TeamMutations!
   toggleConfig(field: ConfigFields!): Boolean!
@@ -688,8 +688,6 @@ type OfferReadinessResult {
   btc_channels: ChannelSummary!
   has_pending_order: Boolean!
   is_peer_connected: Boolean!
-  onchain_asset_balance: String!
-  onchain_balance_sats: String!
 }
 
 type OnChainBalance {
@@ -933,11 +931,12 @@ type SessionInfo {
   type: String
 }
 
-input SetupTradeCapacityInput {
+input SetupTradePartnerInput {
   ambossAssetId: String!
   assetAmount: String!
   assetRate: String!
   magmaOfferId: String!
+  openAssetChannel: Boolean
   satsAmount: String
   swapNodePubkey: String!
   swapNodeSockets: [String!]
@@ -946,7 +945,7 @@ input SetupTradeCapacityInput {
   transactionType: TapTransactionType!
 }
 
-type SetupTradeCapacityResult {
+type SetupTradePartnerResult {
   magmaOrderAmountAsset: String
   magmaOrderAmountSats: String
   magmaOrderFeeSats: String
@@ -954,8 +953,6 @@ type SetupTradeCapacityResult {
   magmaOrderStatus: String
   outboundChannelOutputIndex: Int
   outboundChannelTxid: String
-  skippedMagmaOrder: Boolean
-  skippedOutboundChannel: Boolean
   success: Boolean!
 }
 

--- a/schema.gql
+++ b/schema.gql
@@ -937,6 +937,7 @@ input SetupTradeCapacityInput {
   ambossAssetId: String!
   assetAmount: String!
   assetRate: String!
+  feeRateSatPerVbyte: Int
   magmaOfferId: String!
   openOutboundAssetChannel: Boolean
   satsAmount: String

--- a/src/client/src/graphql/types.ts
+++ b/src/client/src/graphql/types.ts
@@ -1305,6 +1305,7 @@ export type SetupTradeCapacityInput = {
   assetAmount: Scalars['String']['input'];
   assetRate: Scalars['String']['input'];
   magmaOfferId: Scalars['String']['input'];
+  openOutboundAssetChannel?: InputMaybe<Scalars['Boolean']['input']>;
   satsAmount?: InputMaybe<Scalars['String']['input']>;
   swapNodePubkey: Scalars['String']['input'];
   swapNodeSockets?: InputMaybe<Array<Scalars['String']['input']>>;

--- a/src/client/src/layouts/sidebar/SidebarTrade.tsx
+++ b/src/client/src/layouts/sidebar/SidebarTrade.tsx
@@ -302,6 +302,7 @@ export const SidebarTrade: FC<{ embedded?: boolean }> = ({
           tapdAssetId: offerAsset.assetId || undefined,
           tapdGroupKey: offerAsset.groupKey || undefined,
           satsAmount: isAssetPurchase ? satsAmount : undefined,
+          openAssetChannel: !isAssetPurchase ? !hasAssetChannel : undefined,
         },
       },
     });

--- a/src/client/src/layouts/sidebar/SidebarTrade.tsx
+++ b/src/client/src/layouts/sidebar/SidebarTrade.tsx
@@ -302,7 +302,9 @@ export const SidebarTrade: FC<{ embedded?: boolean }> = ({
           tapdAssetId: offerAsset.assetId || undefined,
           tapdGroupKey: offerAsset.groupKey || undefined,
           satsAmount: isAssetPurchase ? satsAmount : undefined,
-          openAssetChannel: !isAssetPurchase ? !hasAssetChannel : undefined,
+          openOutboundAssetChannel: !isAssetPurchase
+            ? !hasAssetChannel
+            : undefined,
         },
       },
     });

--- a/src/server/modules/api/magma/magma.resolver.spec.ts
+++ b/src/server/modules/api/magma/magma.resolver.spec.ts
@@ -435,20 +435,71 @@ describe('MagmaResolver', () => {
         });
       });
 
-      it('SALE: throws not-implemented error', async () => {
-        await expect(
-          setupResolver.setupTradeCapacity(userId, saleInput)
-        ).rejects.toThrow('Selling not implemented yet');
+      it('SALE: creates Magma order in sats + opens asset outbound channel', async () => {
+        const result = await setupResolver.setupTradeCapacity(
+          userId,
+          saleInput
+        );
+
+        // Magma order size = assetAmount * 1e8 / assetRate = 1000 * 1e8 / 1000000 = 100000 sats
+        expect(mockFetchService.graphqlFetchWithProxy).toHaveBeenCalledWith(
+          magmaUrl,
+          expect.anything(),
+          expect.objectContaining({
+            input: expect.objectContaining({ size: '100000' }),
+          }),
+          expect.any(Object)
+        );
+
+        // Invoice paid and channel opening detected
+        expect(mockNodeService.pay).toHaveBeenCalledWith(userId.id, {
+          request: 'lnbc1invoice',
+        });
+        expect(mockNodeService.waitForChannelFromPeer).toHaveBeenCalledWith(
+          userId.id,
+          swapPubkey,
+          120_000
+        );
+
+        // Asset outbound channel opened
+        expect(mockTapdNodeService.fundAssetChannel).toHaveBeenCalledWith({
+          id: userId.id,
+          peerPubkey: swapPubkey,
+          assetAmount: '1000',
+          assetId: 'deadbeef'.repeat(8),
+        });
+
+        // BTC channel NOT opened
+        expect(mockNodeService.openChannel).not.toHaveBeenCalled();
+
+        expect(result).toEqual({
+          success: true,
+          magmaOrderId: 'order-1',
+          magmaOrderStatus: 'WAITING',
+          magmaOrderAmountSats: '1000',
+          magmaOrderFeeSats: '500',
+          outboundChannelTxid: 'asset-txid',
+          outboundChannelOutputIndex: 1,
+        });
       });
 
-      it('SALE with grouped asset: throws not-implemented error', async () => {
-        await expect(
-          setupResolver.setupTradeCapacity(userId, {
-            ...saleInput,
-            tapdAssetId: undefined,
-            tapdGroupKey: 'cafebabe'.repeat(8),
-          })
-        ).rejects.toThrow('Selling not implemented yet');
+      it('SALE with grouped asset: opens asset channel using groupKey', async () => {
+        const result = await setupResolver.setupTradeCapacity(userId, {
+          ...saleInput,
+          tapdAssetId: undefined,
+          tapdGroupKey: 'cafebabe'.repeat(8),
+        });
+
+        expect(mockTapdNodeService.fundAssetChannel).toHaveBeenCalledWith({
+          id: userId.id,
+          peerPubkey: swapPubkey,
+          assetAmount: '1000',
+          groupKey: 'cafebabe'.repeat(8),
+        });
+
+        expect(result.outboundChannelTxid).toBe('asset-txid');
+        expect(result.outboundChannelOutputIndex).toBe(1);
+        expect(result.magmaOrderAmountSats).toBe('1000');
       });
     });
 
@@ -482,13 +533,21 @@ describe('MagmaResolver', () => {
         expect(result.magmaOrderAmountSats).toBeUndefined();
       });
 
-      it('SALE: throws not-implemented error', async () => {
-        await expect(
-          setupResolver.setupTradeCapacity(userId, {
-            ...saleInput,
-            satsAmount: undefined,
-          })
-        ).rejects.toThrow('Selling not implemented yet');
+      it('SALE: always opens asset outbound channel (no satsAmount opt-out)', async () => {
+        const result = await setupResolver.setupTradeCapacity(userId, {
+          ...saleInput,
+          satsAmount: undefined,
+        });
+
+        expect(mockTapdNodeService.fundAssetChannel).toHaveBeenCalledWith({
+          id: userId.id,
+          peerPubkey: swapPubkey,
+          assetAmount: '1000',
+          assetId: 'deadbeef'.repeat(8),
+        });
+        expect(mockNodeService.openChannel).not.toHaveBeenCalled();
+        expect(result.outboundChannelTxid).toBe('asset-txid');
+        expect(result.magmaOrderAmountSats).toBe('1000');
       });
     });
 

--- a/src/server/modules/api/magma/magma.resolver.spec.ts
+++ b/src/server/modules/api/magma/magma.resolver.spec.ts
@@ -384,6 +384,7 @@ describe('MagmaResolver', () => {
       swapNodePubkey: swapPubkey,
       swapNodeSockets: ['127.0.0.1:9735'],
       tapdAssetId: 'deadbeef'.repeat(8),
+      openAssetChannel: true,
     };
 
     // ── Case 1: no channels — full setup ──
@@ -533,20 +534,16 @@ describe('MagmaResolver', () => {
         expect(result.magmaOrderAmountSats).toBeUndefined();
       });
 
-      it('SALE: always opens asset outbound channel (no satsAmount opt-out)', async () => {
+      it('SALE: skips asset channel when openAssetChannel is omitted', async () => {
         const result = await setupResolver.setupTradeCapacity(userId, {
           ...saleInput,
-          satsAmount: undefined,
+          openAssetChannel: undefined,
         });
 
-        expect(mockTapdNodeService.fundAssetChannel).toHaveBeenCalledWith({
-          id: userId.id,
-          peerPubkey: swapPubkey,
-          assetAmount: '1000',
-          assetId: 'deadbeef'.repeat(8),
-        });
+        expect(mockTapdNodeService.fundAssetChannel).not.toHaveBeenCalled();
         expect(mockNodeService.openChannel).not.toHaveBeenCalled();
-        expect(result.outboundChannelTxid).toBe('asset-txid');
+        expect(result.outboundChannelTxid).toBeUndefined();
+        expect(result.outboundChannelOutputIndex).toBeUndefined();
         expect(result.magmaOrderAmountSats).toBe('1000');
       });
     });

--- a/src/server/modules/api/magma/magma.resolver.spec.ts
+++ b/src/server/modules/api/magma/magma.resolver.spec.ts
@@ -384,7 +384,7 @@ describe('MagmaResolver', () => {
       swapNodePubkey: swapPubkey,
       swapNodeSockets: ['127.0.0.1:9735'],
       tapdAssetId: 'deadbeef'.repeat(8),
-      openAssetChannel: true,
+      openOutboundAssetChannel: true,
     };
 
     // ── Case 1: no channels — full setup ──
@@ -534,10 +534,10 @@ describe('MagmaResolver', () => {
         expect(result.magmaOrderAmountSats).toBeUndefined();
       });
 
-      it('SALE: skips asset channel when openAssetChannel is omitted', async () => {
+      it('SALE: skips asset channel when openOutboundAssetChannel is omitted', async () => {
         const result = await setupResolver.setupTradeCapacity(userId, {
           ...saleInput,
-          openAssetChannel: undefined,
+          openOutboundAssetChannel: undefined,
         });
 
         expect(mockTapdNodeService.fundAssetChannel).not.toHaveBeenCalled();

--- a/src/server/modules/api/magma/magma.resolver.spec.ts
+++ b/src/server/modules/api/magma/magma.resolver.spec.ts
@@ -467,6 +467,7 @@ describe('MagmaResolver', () => {
           id: userId.id,
           peerPubkey: swapPubkey,
           assetAmount: '1000',
+          feeRateSatPerVbyte: 1,
           assetId: 'deadbeef'.repeat(8),
         });
 
@@ -495,6 +496,7 @@ describe('MagmaResolver', () => {
           id: userId.id,
           peerPubkey: swapPubkey,
           assetAmount: '1000',
+          feeRateSatPerVbyte: 1,
           groupKey: 'cafebabe'.repeat(8),
         });
 

--- a/src/server/modules/api/magma/magma.resolver.ts
+++ b/src/server/modules/api/magma/magma.resolver.ts
@@ -514,6 +514,11 @@ export class MagmaResolver {
             };
           }
 
+          // No openAssetChannel flag → outbound asset channel already exists, skip.
+          if (!input.openAssetChannel) {
+            return undefined;
+          }
+
           const [channelResult, error] = await toWithError(
             this.tapdNodeService.fundAssetChannel({
               id: user.id,

--- a/src/server/modules/api/magma/magma.resolver.ts
+++ b/src/server/modules/api/magma/magma.resolver.ts
@@ -125,9 +125,6 @@ export class MagmaResolver {
     const ambossAuth = await this.ambossTokenService.getOrCreate(user);
     const result = await auto<SetupTradeCapacityAuto>({
       validate: async (): Promise<SetupTradeCapacityAuto['validate']> => {
-        if (input.transactionType == TapTransactionType.SALE) {
-          throw new GraphQLError(`Selling not implemented yet`);
-        }
         if (!input.assetAmount || BigInt(input.assetAmount) <= 0) {
           throw new GraphQLError('Asset amount must be greater than zero');
         }

--- a/src/server/modules/api/magma/magma.resolver.ts
+++ b/src/server/modules/api/magma/magma.resolver.ts
@@ -524,6 +524,7 @@ export class MagmaResolver {
               id: user.id,
               peerPubkey: input.swapNodePubkey,
               assetAmount: input.assetAmount,
+              feeRateSatPerVbyte: input.feeRateSatPerVbyte ?? 1,
               ...(input.tapdGroupKey
                 ? { groupKey: input.tapdGroupKey }
                 : { assetId: input.tapdAssetId }),

--- a/src/server/modules/api/magma/magma.resolver.ts
+++ b/src/server/modules/api/magma/magma.resolver.ts
@@ -514,8 +514,8 @@ export class MagmaResolver {
             };
           }
 
-          // No openAssetChannel flag → outbound asset channel already exists, skip.
-          if (!input.openAssetChannel) {
+          // No openOutboundAssetChannel flag → outbound asset channel already exists, skip.
+          if (!input.openOutboundAssetChannel) {
             return undefined;
           }
 

--- a/src/server/modules/api/magma/magma.types.ts
+++ b/src/server/modules/api/magma/magma.types.ts
@@ -380,6 +380,14 @@ export class SetupTradeCapacityInput {
    */
   @Field({ nullable: true })
   satsAmount?: string;
+
+  /**
+   * Pass `true` to open an outbound asset channel for a SALE. Omit (or pass
+   * `false`) to skip — e.g. when the node already has sufficient asset outbound
+   * with the peer. Unused for PURCHASE.
+   */
+  @Field({ nullable: true })
+  openAssetChannel?: boolean;
 }
 
 @ObjectType()

--- a/src/server/modules/api/magma/magma.types.ts
+++ b/src/server/modules/api/magma/magma.types.ts
@@ -388,6 +388,14 @@ export class SetupTradeCapacityInput {
    */
   @Field({ nullable: true })
   openOutboundAssetChannel?: boolean;
+
+  /**
+   * On-chain fee rate in sats/vbyte for the outbound asset channel open (SALE
+   * only). tapd requires this to be set explicitly; defaults to 1 sat/vbyte
+   * if omitted. Unused for PURCHASE.
+   */
+  @Field(() => Int, { nullable: true })
+  feeRateSatPerVbyte?: number;
 }
 
 @ObjectType()

--- a/src/server/modules/api/magma/magma.types.ts
+++ b/src/server/modules/api/magma/magma.types.ts
@@ -387,7 +387,7 @@ export class SetupTradeCapacityInput {
    * with the peer. Unused for PURCHASE.
    */
   @Field({ nullable: true })
-  openAssetChannel?: boolean;
+  openOutboundAssetChannel?: boolean;
 }
 
 @ObjectType()


### PR DESCRIPTION
Remove the placeholder guard that blocked SALE — the full flow (sats-denominated order size, HODL invoice payment, outbound asset channel via fundAssetChannel) was already implemented. Replace the three "throws not-implemented" spec stubs with real assertions.