### PR TITLE
fix: read TA channel cltv/fee from invoice route hint in rebalance

### DIFF
--- a/src/server/modules/api/trade/trade.resolver.spec.ts
+++ b/src/server/modules/api/trade/trade.resolver.spec.ts
@@ -73,6 +73,7 @@ describe('TradeResolver', () => {
     getIdentity: jest.fn(),
     getHeight: jest.fn(),
     createInvoice: jest.fn(),
+    decodePaymentRequest: jest.fn(),
     payViaRoutes: jest.fn(),
   };
   const mockTapdNodeService = {
@@ -98,6 +99,22 @@ describe('TradeResolver', () => {
       payment: 'bb'.repeat(32),
       request: 'lnbc...',
       secret: 'cc'.repeat(32),
+    });
+    // Default decoded invoice: a single TA-channel route hint via the peer
+    // with the default channel cltv_delta and a typical forwarding fee.
+    // Tests that need different cltv/fees override this per-test.
+    mockNodeService.decodePaymentRequest.mockResolvedValue({
+      routes: [
+        [
+          {
+            public_key: peerPubkey,
+            channel: '800000x1x0',
+            cltv_delta: 40,
+            base_fee_mtokens: '1000',
+            fee_rate: 2500,
+          },
+        ],
+      ],
     });
     mockNodeService.payViaRoutes.mockResolvedValue({ is_confirmed: true });
     mockTapdNodeService.getAssetChannelBalances.mockResolvedValue([]);
@@ -611,7 +628,20 @@ describe('TradeResolver', () => {
       expect(routes[0].timeout).toBeGreaterThan(hop1.timeout);
     });
 
-    it('uses cltv_delta fallback of 40 when both getChannel calls fail', async () => {
+    it('uses cltv_delta fallback of 40 when route hint has no cltv_delta', async () => {
+      mockNodeService.decodePaymentRequest.mockResolvedValue({
+        routes: [
+          [
+            {
+              public_key: peerPubkey,
+              channel: taChannelScid,
+              base_fee_mtokens: '0',
+              fee_rate: 0,
+            },
+          ],
+        ],
+      });
+
       await priv.rebalanceTaChannel(
         userId,
         peerPubkey,
@@ -632,8 +662,110 @@ describe('TradeResolver', () => {
       const hop2Timeout = routes[0].hops[0].timeout;
       // hop2Timeout = 800_000 + 24 (DEFAULT_INVOICE_CLTV_DELTA) + 3 = 800_027
       expect(hop2Timeout).toBe(800_027);
-      // routes[0].timeout = hop2Timeout + max(40, 40) (DEFAULT_CHANNEL_CLTV_DELTA) = 800_067
+      // routes[0].timeout = hop2Timeout + 40 (DEFAULT_CHANNEL_CLTV_DELTA) = 800_067
       expect(routes[0].timeout).toBe(800_067);
+    });
+
+    it('uses cltv_delta from the TA channel route hint', async () => {
+      mockNodeService.decodePaymentRequest.mockResolvedValue({
+        routes: [
+          [
+            {
+              public_key: peerPubkey,
+              channel: taChannelScid,
+              cltv_delta: 144,
+              base_fee_mtokens: '0',
+              fee_rate: 0,
+            },
+          ],
+        ],
+      });
+
+      await priv.rebalanceTaChannel(
+        userId,
+        peerPubkey,
+        taChannelScid,
+        undefined,
+        taChannelCapacity,
+        btcChannel,
+        rebalanceSats,
+        currentHeight,
+        myPubkey
+      );
+
+      const routes = mockNodeService.payViaRoutes.mock.calls[0][1]
+        .routes as Array<{
+        hops: Array<{ timeout: number }>;
+        timeout: number;
+      }>;
+      const hop2Timeout = routes[0].hops[0].timeout;
+      expect(hop2Timeout).toBe(800_027);
+      expect(routes[0].timeout).toBe(800_027 + 144);
+    });
+
+    it('throws when no TA route hint is found in the invoice', async () => {
+      mockNodeService.decodePaymentRequest.mockResolvedValue({ routes: [] });
+
+      await expect(
+        priv.rebalanceTaChannel(
+          userId,
+          peerPubkey,
+          taChannelScid,
+          undefined,
+          taChannelCapacity,
+          btcChannel,
+          rebalanceSats,
+          currentHeight,
+          myPubkey
+        )
+      ).rejects.toThrow('no TA channel route hint');
+    });
+
+    it('selects the route hint matching taChannelPartnerScidAlias', async () => {
+      const alias = '16000000x0x1';
+      mockNodeService.decodePaymentRequest.mockResolvedValue({
+        routes: [
+          [
+            {
+              public_key: peerPubkey,
+              channel: 'btc-private-1',
+              cltv_delta: 80,
+              base_fee_mtokens: '0',
+              fee_rate: 0,
+            },
+          ],
+          [
+            {
+              public_key: peerPubkey,
+              channel: alias,
+              cltv_delta: 144,
+              base_fee_mtokens: '0',
+              fee_rate: 0,
+            },
+          ],
+        ],
+      });
+
+      await priv.rebalanceTaChannel(
+        userId,
+        peerPubkey,
+        taChannelScid,
+        alias,
+        taChannelCapacity,
+        btcChannel,
+        rebalanceSats,
+        currentHeight,
+        myPubkey
+      );
+
+      const routes = mockNodeService.payViaRoutes.mock.calls[0][1]
+        .routes as Array<{
+        hops: Array<{ channel: string; timeout: number }>;
+        timeout: number;
+      }>;
+      const [, hop2] = routes[0].hops;
+      expect(hop2.channel).toBe(alias);
+      expect(routes[0].timeout).toBe(800_027 + 144);
     });
 
     it('throws when createInvoice fails', async () => {
@@ -708,22 +840,18 @@ describe('TradeResolver', () => {
       ).resolves.toBeUndefined();
     });
 
-    it('computes zero fees and correct tokens when peer policy has zero fee', async () => {
-      mockNodeService.getChannel.mockResolvedValue({
-        id: 'btc-1',
-        policies: [
-          {
-            public_key: peerPubkey,
-            base_fee_mtokens: '0',
-            fee_rate: 0,
-            cltv_delta: 40,
-          },
-          {
-            public_key: myPubkey,
-            base_fee_mtokens: '0',
-            fee_rate: 0,
-            cltv_delta: 40,
-          },
+    it('computes zero fees and correct tokens when route hint has zero fees', async () => {
+      mockNodeService.decodePaymentRequest.mockResolvedValue({
+        routes: [
+          [
+            {
+              public_key: peerPubkey,
+              channel: taChannelScid,
+              cltv_delta: 40,
+              base_fee_mtokens: '0',
+              fee_rate: 0,
+            },
+          ],
         ],
       });
 

--- a/src/server/modules/api/trade/trade.resolver.ts
+++ b/src/server/modules/api/trade/trade.resolver.ts
@@ -947,41 +947,16 @@ export class TradeResolver {
     currentHeight: number,
     identityPubkey: string
   ): Promise<void> {
-    const [[btcChannelInfo, btcChannelInfoError], [taChannelInfo]] =
-      await Promise.all([
-        toWithError(this.nodeService.getChannel(accountId, btcChannel.id)),
-        toWithError(this.nodeService.getChannel(accountId, taChannelScid)),
-      ]);
-
-    if (btcChannelInfoError) {
-      this.logger.warn(
-        'rebalanceTaChannel: could not fetch BTC channel info; using fee defaults',
-        { error: btcChannelInfoError, channelId: btcChannel.id }
-      );
-    }
-
-    const btcPeerPolicy = btcChannelInfo?.policies?.find(
-      (p: { public_key: string }) => p.public_key === peerPubkey
-    );
-    const btcChannelCltvDelta: number =
-      btcPeerPolicy?.cltv_delta ?? DEFAULT_CHANNEL_CLTV_DELTA;
-
-    const taOurPolicy = taChannelInfo?.policies?.find(
-      (p: { public_key: string }) => p.public_key === identityPubkey
-    );
-    const taCltvDelta: number =
-      taOurPolicy?.cltv_delta ?? DEFAULT_CHANNEL_CLTV_DELTA;
-    // Fee the peer charges on the TA channel (their outgoing leg).
-    const taPeerPolicy = taChannelInfo?.policies?.find(
-      (p: { public_key: string }) => p.public_key === peerPubkey
-    );
-    const taBaseFee = BigInt(taPeerPolicy?.base_fee_mtokens ?? '1000');
-    const taFeeRate = BigInt(taPeerPolicy?.fee_rate ?? 2500);
-
+    // Create the self-payment invoice with private-channel route hints so
+    // LND embeds the TA channel's SCID alias and the peer's gossiped policy
+    // on it (cltv_delta, fees). The alias is a tapd virtual SCID — looking
+    // it up via getChannel doesn't return the same gossip entry the peer
+    // actually enforces, so the route hint is the reliable source.
     const [invoice, invoiceError] = await toWithError(
       this.nodeService.createInvoice(accountId, {
         tokens: rebalanceSats,
         cltv_delta: DEFAULT_INVOICE_CLTV_DELTA,
+        is_including_private_channels: true,
       })
     );
 
@@ -991,9 +966,34 @@ export class TradeResolver {
       );
     }
 
+    const [decoded, decodeError] = await toWithError(
+      this.nodeService.decodePaymentRequest(accountId, invoice.request)
+    );
+    if (decodeError || !decoded) {
+      throw new Error(
+        'Rebalance failed: could not decode self-payment invoice'
+      );
+    }
+
+    const taRouteHint = this.findVirtualScidHint(
+      decoded.routes,
+      peerPubkey,
+      taChannelPartnerScidAlias
+    );
+    if (!taRouteHint) {
+      throw new Error(
+        'Rebalance failed: no TA channel route hint in self-payment invoice'
+      );
+    }
+
+    const taCltvDelta: number =
+      taRouteHint.cltv_delta ?? DEFAULT_CHANNEL_CLTV_DELTA;
+    const taBaseFee = BigInt(taRouteHint.base_fee_mtokens ?? '0');
+    const taFeeRate = BigInt(taRouteHint.fee_rate ?? 0);
+
     const invoiceCltvDelta = DEFAULT_INVOICE_CLTV_DELTA;
     const hop2Timeout = currentHeight + invoiceCltvDelta + CLTV_BLOCK_BUFFER;
-    const hopCltvDelta = Math.max(taCltvDelta, btcChannelCltvDelta);
+    const hopCltvDelta = taCltvDelta;
     const hop1Timeout = hop2Timeout + hopCltvDelta;
 
     const forwardMtokens = BigInt(rebalanceSats) * BigInt(1000);
@@ -1023,9 +1023,10 @@ export class TradeResolver {
         },
         {
           // Hop 2: peer → us via TA channel (final destination, fee=0).
-          // Use partner_scid_alias (the peer's own local alias) — the real SCID
-          // and our own alias_scids give UnknownNextPeer for private TA channels.
-          channel: taChannelPartnerScidAlias ?? taChannelScid,
+          // Use the alias the peer published in the invoice route hint — the
+          // canonical SCID and our own alias_scids give UnknownNextPeer for
+          // private TA channels.
+          channel: taRouteHint.channel,
           channel_capacity: taChannelCapacity,
           fee: 0,
           fee_mtokens: '0',
@@ -1136,26 +1137,42 @@ export class TradeResolver {
    */
   private findVirtualScidHint(
     routes: Array<
-      Array<{ public_key: string; channel?: string; cltv_delta?: number }>
+      Array<{
+        public_key: string;
+        channel?: string;
+        cltv_delta?: number;
+        base_fee_mtokens?: string;
+        fee_rate?: number;
+      }>
     >,
-    peerPubkey: string
-  ): { channel: string; cltv_delta?: number } | undefined {
+    peerPubkey: string,
+    expectedChannel?: string
+  ):
+    | {
+        channel: string;
+        cltv_delta?: number;
+        base_fee_mtokens?: string;
+        fee_rate?: number;
+      }
+    | undefined {
     for (const route of routes) {
       const peerIdx = route.findIndex(hop => hop.public_key === peerPubkey);
       if (peerIdx === -1) continue;
 
-      if (route[peerIdx].channel) {
-        return {
-          channel: route[peerIdx].channel as string,
-          cltv_delta: route[peerIdx].cltv_delta,
-        };
-      }
+      const candidate = route[peerIdx].channel
+        ? route[peerIdx]
+        : // lightning package convention: channel on the next entry (destination)
+          route[peerIdx + 1];
 
-      // lightning package convention: channel on the next entry (destination)
-      const nextHop = route[peerIdx + 1];
-      if (nextHop?.channel) {
-        return { channel: nextHop.channel, cltv_delta: nextHop.cltv_delta };
-      }
+      if (!candidate?.channel) continue;
+      if (expectedChannel && candidate.channel !== expectedChannel) continue;
+
+      return {
+        channel: candidate.channel,
+        cltv_delta: candidate.cltv_delta,
+        base_fee_mtokens: candidate.base_fee_mtokens,
+        fee_rate: candidate.fee_rate,
+      };
     }
     return undefined;
   }


### PR DESCRIPTION
## Summary

The circular self-payment used by `topUpAssetChannelSats` to top up the BTC reserve of a Taproot Asset channel was failing with `IncorrectCltvExpiry` when forwarding through the TA channel's virtual SCID alias (e.g. `16000000x0x1`).

The previous code looked up the TA channel policy via `getChannel(taChannelPartnerScidAlias ?? taChannelScid)` and used its `cltv_delta`. This is unreliable because:

- The tapd-issued virtual SCID alias is not a normal LND channel id, so `GetChanInfo` may return a stale or different policy than the one the peer actually enforces when forwarding HTLCs through the alias.
- The peer's gossiped policy on the alias can require a higher `cltv_delta` (e.g. `144`) than the canonical channel's policy (e.g. `80`), causing `IncorrectCltvExpiry` when the sender uses the canonical value.

This fix mirrors what the buy flow already does (`getBuyQuote` → `findVirtualScidHint`): create the self-payment invoice with `is_including_private_channels: true`, decode the BOLT11, and read `cltv_delta`, `base_fee_mtokens`, and `fee_rate` from the route hint that matches the peer + TA alias. The hop's channel id is also taken from the route hint so the peer routes through the alias the invoice points at.

Both prior `getChannel` calls in `rebalanceTaChannel` are removed; `findVirtualScidHint` is extended to extract fee fields and accept an optional expected channel for disambiguation.

## Test plan

- [x] `npm run test -- --testPathPattern="trade"` — 49 tests pass, including 3 new ones covering cltv extraction from the route hint, missing-hint error, and hint disambiguation by alias
- [x] `npm run lint:check`
- [x] `npm run build`
- [ ] Manual verification: trigger `topUpAssetChannelSats` on a node where the TA alias policy enforces a higher cltv_delta than the BTC channel and confirm the rebalance succeeds