### PR TITLE
feat: show asset balance columns in pending asset channels table

### DIFF
--- a/src/client/src/graphql/queries/__generated__/getPendingChannels.generated.tsx
+++ b/src/client/src/graphql/queries/__generated__/getPendingChannels.generated.tsx
@@ -35,6 +35,8 @@ export type GetPendingChannelsQuery = {
     asset?: {
       __typename?: 'ChannelAsset';
       asset_id: string;
+      asset_name: string;
+      asset_precision: number;
       group_key?: string | null;
       local_balance: string;
       remote_balance: string;
@@ -70,6 +72,8 @@ export const GetPendingChannelsDocument = gql`
       }
       asset {
         asset_id
+        asset_name
+        asset_precision
         group_key
         local_balance
         remote_balance

--- a/src/client/src/graphql/queries/getPendingChannels.ts
+++ b/src/client/src/graphql/queries/getPendingChannels.ts
@@ -27,6 +27,8 @@ export const GET_PENDING_CHANNELS = gql`
       }
       asset {
         asset_id
+        asset_name
+        asset_precision
         group_key
         local_balance
         remote_balance

--- a/src/client/src/views/channels/channels/ChannelTable.tsx
+++ b/src/client/src/views/channels/channels/ChannelTable.tsx
@@ -52,13 +52,12 @@ import { useAccount } from '../../../hooks/UseAccount';
 import { ChannelDetails } from './ChannelDetails';
 import { defaultHiddenColumns } from './helpers';
 import { VisibilityState } from '@tanstack/react-table';
+import { Asset, REMOTE_COLOR } from '../types';
 
 const getBar = (top: number, bottom: number) => {
   const percent = (top / bottom) * 100;
   return Math.min(percent, 100);
 };
-
-const REMOTE_COLOR = 'rgba(209, 213, 219, 0.6)';
 
 // ── NoteCell ──────────────────────────────────────────────────────────────────
 
@@ -239,15 +238,7 @@ export const ChannelTable = ({
     const channelData = assetOnly
       ? allChannels.filter(c => c.asset)
       : allChannels;
-    const map = new Map<
-      string,
-      {
-        asset_id: string;
-        asset_name: string;
-        group_key?: string;
-        asset_precision: number;
-      }
-    >();
+    const map = new Map<string, Asset>();
     for (const c of channelData) {
       if (c.asset) {
         const key = c.asset.group_key || c.asset.asset_id;

--- a/src/client/src/views/channels/pendingChannels/PendingChannels.tsx
+++ b/src/client/src/views/channels/pendingChannels/PendingChannels.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import React, { useMemo } from 'react';
 import toast from 'react-hot-toast';
 import { useGetPendingChannelsQuery } from '../../../graphql/queries/__generated__/getPendingChannels.generated';
 import { getErrorContent } from '../../../utils/error';
@@ -11,6 +11,10 @@ import Table from '../../../components/table';
 import { Price } from '../../../components/price/Price';
 import { ColumnDef } from '@tanstack/react-table';
 import { PendingChannel } from '../../../graphql/types';
+import { BalanceBars } from '../../../components/balance';
+import { colorFromString } from '../../../utils/color';
+import { formatAssetAmount, getPercent } from '../../../utils/helpers';
+import { Asset, REMOTE_COLOR } from '../types';
 
 export const PendingChannels = ({
   assetOnly,
@@ -19,19 +23,93 @@ export const PendingChannels = ({
     onError: error => toast.error(getErrorContent(error)),
   });
 
+  const uniqueAssets = useMemo(() => {
+    const allChannels = data?.getPendingChannels || [];
+    const channelData = assetOnly
+      ? allChannels.filter(c => c.asset)
+      : allChannels;
+    const map = new Map<string, Asset>();
+    for (const c of channelData) {
+      if (c.asset) {
+        const key = c.asset.group_key || c.asset.asset_id;
+        if (!map.has(key)) {
+          map.set(key, {
+            asset_id: c.asset.asset_id,
+            asset_name: c.asset.asset_name,
+            group_key: c.asset.group_key ?? undefined,
+            asset_precision: c.asset.asset_precision,
+          });
+        }
+      }
+    }
+    return map;
+  }, [data, assetOnly]);
+
   const tableData = useMemo(() => {
     const allChannels = data?.getPendingChannels || [];
     const channelData = assetOnly
       ? allChannels.filter(c => c.asset)
       : allChannels;
 
-    return channelData.map(c => ({
-      ...c,
-      alias: c.partner_node_info.node?.alias || 'Unknown',
-      capacity: (c.local_balance || 0) + (c.remote_balance || 0),
-      force_closed: c.is_timelocked ? 'Yes' : '-',
-    }));
-  }, [data, assetOnly]);
+    return channelData.map(c => {
+      const assetFields: Record<string, React.ReactNode> = {};
+      const channelAssetKey = c.asset
+        ? c.asset.group_key || c.asset.asset_id
+        : null;
+      for (const [key, assetInfo] of uniqueAssets) {
+        const match = channelAssetKey === key;
+        const prefix = `asset_${key}`;
+        const precision = assetInfo.asset_precision;
+
+        assetFields[`${prefix}_capacity`] = match
+          ? formatAssetAmount(c.asset!.capacity, precision)
+          : null;
+        assetFields[`${prefix}_local`] = match
+          ? formatAssetAmount(c.asset!.local_balance, precision)
+          : null;
+        assetFields[`${prefix}_remote`] = match
+          ? formatAssetAmount(c.asset!.remote_balance, precision)
+          : null;
+        assetFields[`${prefix}_balancePercent`] = match
+          ? getPercent(
+              Number(c.asset!.local_balance),
+              Number(c.asset!.remote_balance)
+            )
+          : 0;
+
+        const assetColor = colorFromString(key);
+        assetFields[`${prefix}_balanceBar`] = match ? (
+          <div className="min-w-45">
+            <BalanceBars
+              local={getPercent(
+                Number(c.asset!.local_balance),
+                Number(c.asset!.remote_balance)
+              )}
+              remote={getPercent(
+                Number(c.asset!.remote_balance),
+                Number(c.asset!.local_balance)
+              )}
+              formatLocal={formatAssetAmount(c.asset!.local_balance, precision)}
+              formatRemote={formatAssetAmount(
+                c.asset!.remote_balance,
+                precision
+              )}
+              localColor={assetColor}
+              remoteColor={REMOTE_COLOR}
+            />
+          </div>
+        ) : null;
+      }
+
+      return {
+        ...c,
+        ...assetFields,
+        alias: c.partner_node_info.node?.alias || 'Unknown',
+        capacity: (c.local_balance || 0) + (c.remote_balance || 0),
+        force_closed: c.is_timelocked ? 'Yes' : '-',
+      };
+    });
+  }, [data, assetOnly, uniqueAssets]);
 
   const columns = useMemo<ColumnDef<PendingChannel, any>[]>(
     () => [
@@ -167,8 +245,63 @@ export const PendingChannels = ({
           </div>
         ),
       },
+      ...Array.from(uniqueAssets.entries()).map(([key, assetInfo]) => {
+        const prefix = `asset_${key}`;
+        const name = assetInfo.asset_name || assetInfo.asset_id.slice(0, 8);
+
+        return {
+          id: prefix,
+          header: `Asset (${name})`,
+          columns: [
+            {
+              header: 'Capacity',
+              accessorKey: `${prefix}_capacity`,
+              cell: ({ cell }: any) => {
+                const val = cell.getValue();
+                return val != null ? (
+                  <div className="whitespace-nowrap">{val}</div>
+                ) : (
+                  <span className="text-muted-foreground">-</span>
+                );
+              },
+            },
+            {
+              header: 'Local',
+              accessorKey: `${prefix}_local`,
+              cell: ({ cell }: any) => {
+                const val = cell.getValue();
+                return val != null ? (
+                  <div className="whitespace-nowrap">{val}</div>
+                ) : (
+                  <span className="text-muted-foreground">-</span>
+                );
+              },
+            },
+            {
+              header: 'Remote',
+              accessorKey: `${prefix}_remote`,
+              cell: ({ cell }: any) => {
+                const val = cell.getValue();
+                return val != null ? (
+                  <div className="whitespace-nowrap">{val}</div>
+                ) : (
+                  <span className="text-muted-foreground">-</span>
+                );
+              },
+            },
+            {
+              header: 'Balance',
+              accessorKey: `${prefix}_balanceBar`,
+              cell: ({ cell }: any) =>
+                cell.renderValue() || (
+                  <span className="text-muted-foreground">-</span>
+                ),
+            },
+          ],
+        };
+      }),
     ],
-    []
+    [uniqueAssets]
   );
 
   if (loading) {

--- a/src/client/src/views/channels/types.ts
+++ b/src/client/src/views/channels/types.ts
@@ -1,0 +1,8 @@
+export const REMOTE_COLOR = 'rgba(209, 213, 219, 0.6)';
+
+export type Asset = {
+  asset_id: string;
+  asset_name: string;
+  group_key?: string;
+  asset_precision: number;
+};


### PR DESCRIPTION
Adds dynamic asset capacity/local/remote/balance-bar columns to the pending channels view, matching the display already present for open channels. Also adds asset_name and asset_precision to the getPendingChannels query so labels and formatted amounts are correct.