### PR TITLE
fix: when using DB based auth, fix `/setup` route [AMB-2551]

### DIFF
--- a/src/client/src/pages/SetupPage.tsx
+++ b/src/client/src/pages/SetupPage.tsx
@@ -1,4 +1,4 @@
-import { useForm } from 'react-hook-form';
+import { Controller, useForm } from 'react-hook-form';
 import { appendBasePath } from '../utils/basePath';
 import { TopSection } from '../views/homepage/Top';
 import { useCreateInitialUserMutation } from '../graphql/mutations/__generated__/createInitialUser.generated';
@@ -21,7 +21,7 @@ type SetupFormValues = {
 
 const SetupPage = () => {
   const {
-    register,
+    control,
     handleSubmit,
     setError,
     formState: { errors },
@@ -75,18 +75,25 @@ const SetupPage = () => {
                   >
                     Email
                   </label>
-                  <Input
-                    id="email"
-                    type="email"
-                    placeholder="admin@example.com"
-                    autoComplete="email"
-                    {...register('email', {
+                  <Controller
+                    name="email"
+                    control={control}
+                    rules={{
                       required: 'Email is required',
                       pattern: {
                         value: /^[^\s@]+@[^\s@]+\.[^\s@]+$/,
                         message: 'Please enter a valid email address',
                       },
-                    })}
+                    }}
+                    render={({ field }) => (
+                      <Input
+                        {...field}
+                        id="email"
+                        type="email"
+                        placeholder="admin@example.com"
+                        autoComplete="email"
+                      />
+                    )}
                   />
                   {errors.email && (
                     <p className="text-xs text-destructive">
@@ -101,18 +108,25 @@ const SetupPage = () => {
                   >
                     Password
                   </label>
-                  <Input
-                    id="password"
-                    type="password"
-                    placeholder="Minimum 8 characters"
-                    autoComplete="new-password"
-                    {...register('password', {
+                  <Controller
+                    name="password"
+                    control={control}
+                    rules={{
                       required: 'Password is required',
                       minLength: {
                         value: 8,
                         message: 'Password must be at least 8 characters',
                       },
-                    })}
+                    }}
+                    render={({ field }) => (
+                      <Input
+                        {...field}
+                        id="password"
+                        type="password"
+                        placeholder="Minimum 8 characters"
+                        autoComplete="new-password"
+                      />
+                    )}
                   />
                   {errors.password && (
                     <p className="text-xs text-destructive">
@@ -127,14 +141,21 @@ const SetupPage = () => {
                   >
                     Confirm Password
                   </label>
-                  <Input
-                    id="confirmPassword"
-                    type="password"
-                    placeholder="Repeat your password"
-                    autoComplete="new-password"
-                    {...register('confirmPassword', {
+                  <Controller
+                    name="confirmPassword"
+                    control={control}
+                    rules={{
                       required: 'Please confirm your password',
-                    })}
+                    }}
+                    render={({ field }) => (
+                      <Input
+                        {...field}
+                        id="confirmPassword"
+                        type="password"
+                        placeholder="Repeat your password"
+                        autoComplete="new-password"
+                      />
+                    )}
                   />
                   {errors.confirmPassword && (
                     <p className="text-xs text-destructive">


### PR DESCRIPTION
#### steps to reproduce

  1. Enable DB-backed auth so thunderHub routes to `/setup`.
  2. make sure the DB is empty to ensure this is a first time setup, eg you can delete the `thunderhub.db`
  3. Start the app and open `http://localhost:3000/setup`.
  4. Enter a valid `email`, `password`, and confirm password.
  5. Submit the form.

#### buggy behavior before the PR

the page shows Email is required even though the email field is filled in and does not allow to proceed.
<hr>
<img width="913" height="687" alt="image" src="https://github.com/user-attachments/assets/6c60da78-c9b0-4b39-9cc8-021cba0da494" />
<hr>

#### issue

- `SetupPage` was using react-hook-form’s `register(...)` API with the shared `shadcn` Input component. That pattern relies on ref-based registration. Our shared `Input` component does not participate in that contract, so the form field could appear editable in the UI while react-hook-form still treated it as unset.

#### solution


- `SetupPage` was updated to use react-hook-form’s `Controller` for `email`, `password`, and `confirmPassword`. That makes the form use the Input component as a controlled field, which matches how the component is already used across the rest of the codebase. Controller does not depend on that ref-registration pattern in the same way. Instead, it treats the field as a controlled component and explicitly passes the value

- shared `src/client/src/components/ui/*` layer is unchanged.