### PR TITLE
Add Pay/Cancel action buttons for pending Magma orders

### DIFF
--- a/schema.gql
+++ b/schema.gql
@@ -690,6 +690,7 @@ type OfferReadinessResult {
   is_peer_connected: Boolean!
   onchain_asset_balance: String!
   onchain_balance_sats: String!
+  pending_order_id: String
 }
 
 type OnChainBalance {

--- a/schema.gql
+++ b/schema.gql
@@ -691,6 +691,7 @@ type OfferReadinessResult {
   onchain_asset_balance: String!
   onchain_balance_sats: String!
   pending_order_id: String
+  pending_order_status: String
 }
 
 type OnChainBalance {

--- a/src/client/src/graphql/queries/__generated__/getOfferReadiness.generated.tsx
+++ b/src/client/src/graphql/queries/__generated__/getOfferReadiness.generated.tsx
@@ -16,6 +16,7 @@ export type GetOfferReadinessQuery = {
       __typename?: 'OfferReadinessResult';
       is_peer_connected: boolean;
       has_pending_order: boolean;
+      pending_order_id?: string | null;
       onchain_balance_sats: string;
       onchain_asset_balance: string;
       btc_channels: {
@@ -45,6 +46,7 @@ export const GetOfferReadinessDocument = gql`
       offer_readiness(input: $input) {
         is_peer_connected
         has_pending_order
+        pending_order_id
         onchain_balance_sats
         onchain_asset_balance
         btc_channels {

--- a/src/client/src/graphql/queries/getOfferReadiness.ts
+++ b/src/client/src/graphql/queries/getOfferReadiness.ts
@@ -7,6 +7,7 @@ export const GET_OFFER_READINESS = gql`
       offer_readiness(input: $input) {
         is_peer_connected
         has_pending_order
+        pending_order_id
         onchain_balance_sats
         onchain_asset_balance
         btc_channels {

--- a/src/client/src/graphql/queries/getOfferReadiness.ts
+++ b/src/client/src/graphql/queries/getOfferReadiness.ts
@@ -8,6 +8,7 @@ export const GET_OFFER_READINESS = gql`
         is_peer_connected
         has_pending_order
         pending_order_id
+        pending_order_status
         onchain_balance_sats
         onchain_asset_balance
         btc_channels {

--- a/src/client/src/graphql/types.ts
+++ b/src/client/src/graphql/types.ts
@@ -947,6 +947,7 @@ export type OfferReadinessResult = {
   is_peer_connected: Scalars['Boolean']['output'];
   onchain_asset_balance: Scalars['String']['output'];
   onchain_balance_sats: Scalars['String']['output'];
+  pending_order_id?: Maybe<Scalars['String']['output']>;
 };
 
 export type OnChainBalance = {
@@ -1304,6 +1305,7 @@ export type SetupTradeCapacityInput = {
   ambossAssetId: Scalars['String']['input'];
   assetAmount: Scalars['String']['input'];
   assetRate: Scalars['String']['input'];
+  feeRateSatPerVbyte?: InputMaybe<Scalars['Int']['input']>;
   magmaOfferId: Scalars['String']['input'];
   openOutboundAssetChannel?: InputMaybe<Scalars['Boolean']['input']>;
   satsAmount?: InputMaybe<Scalars['String']['input']>;

--- a/src/client/src/layouts/sidebar/SidebarTrade.tsx
+++ b/src/client/src/layouts/sidebar/SidebarTrade.tsx
@@ -225,6 +225,7 @@ export const SidebarTrade: FC<{ embedded?: boolean }> = ({
   const hasAssetPending = (assetCh?.pending_count ?? 0) > 0;
   const hasPendingOrder = readiness?.has_pending_order ?? false;
   const pendingOrderId = readiness?.pending_order_id ?? null;
+  const pendingOrderStatus = readiness?.pending_order_status ?? null;
   const onchainSats = Number(readiness?.onchain_balance_sats ?? '0');
   const onchainAsset = BigInt(readiness?.onchain_asset_balance ?? '0');
   const channelsReady = hasBtcChannel && hasAssetChannel;
@@ -572,9 +573,13 @@ export const SidebarTrade: FC<{ embedded?: boolean }> = ({
           {/* Trading capacity */}
           {channelsReady && (
             <div className="flex flex-col gap-1 rounded-md border border-border/60 bg-muted/20 px-3 py-2.5 text-xs">
-              {hasPendingOrder && (
+              {(hasPendingOrder || pendingOrderId) && (
                 <div className="flex items-center gap-1 text-[10px] text-yellow-500 pb-1.5 border-b border-border/40">
-                  <span>Unpaid Magma order pending —</span>
+                  <span>
+                    {hasPendingOrder
+                      ? 'Unpaid Magma order pending —'
+                      : 'Magma order in progress —'}
+                  </span>
                   <a
                     href={`https://magma.amboss.tech/order/${pendingOrderId}`}
                     target="_blank"
@@ -945,64 +950,91 @@ export const SidebarTrade: FC<{ embedded?: boolean }> = ({
               </Button>
             )}
 
-            {hasPendingOrder && (
+            {(hasPendingOrder || pendingOrderId) && (
               <div className="mt-2 rounded-md border border-yellow-500/30 bg-yellow-500/10 p-2.5 space-y-2">
-                <p className="text-[11px] text-yellow-500 font-medium">
-                  An unpaid Magma order is blocking trading. Pay or cancel it to
-                  continue.
-                  <br />
-                  {pendingOrderId && (
-                    <a
-                      href={`https://magma.amboss.tech/order/${pendingOrderId}`}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="text-[11px] text-yellow-500/70 hover:text-yellow-500 underline"
-                    >
-                      View order on Magma
-                    </a>
-                  )}
-                </p>
-                <div className="flex gap-2">
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    className="flex-1 border-yellow-500/50 text-yellow-500 hover:bg-yellow-500/10"
-                    disabled={!pendingOrderId}
-                    onClick={() => {
-                      if (!pendingOrderId) return;
-                      setPayDialogOpen(true);
-                      fetchInvoice({ variables: { orderId: pendingOrderId } });
-                    }}
-                  >
-                    <Zap size={12} className="mr-1" />
-                    Pay order
-                  </Button>
-                  {pendingOrderId && (
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      className="flex-1"
-                      disabled={cancelLoading}
-                      onClick={() =>
-                        cancelOrder({
-                          variables: {
-                            input: {
-                              orderId: pendingOrderId,
-                              cancellationReason:
-                                OrderCancellationReason.UnableToPay,
-                            },
-                          },
-                        })
-                      }
-                    >
-                      {cancelLoading ? (
-                        <Loader2 size={12} className="animate-spin" />
-                      ) : (
-                        'Cancel order'
+                {hasPendingOrder ? (
+                  <>
+                    <p className="text-[11px] text-yellow-500 font-medium">
+                      An unpaid Magma order is blocking trading. Pay or cancel
+                      it to continue.
+                      <br />
+                      {pendingOrderId && (
+                        <a
+                          href={`https://magma.amboss.tech/order/${pendingOrderId}`}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-[11px] text-yellow-500/70 hover:text-yellow-500 underline"
+                        >
+                          View order on Magma
+                        </a>
                       )}
-                    </Button>
-                  )}
-                </div>
+                    </p>
+                    <div className="flex gap-2">
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        className="flex-1 border-yellow-500/50 text-yellow-500 hover:bg-yellow-500/10"
+                        disabled={!pendingOrderId}
+                        onClick={() => {
+                          if (!pendingOrderId) return;
+                          setPayDialogOpen(true);
+                          fetchInvoice({
+                            variables: { orderId: pendingOrderId },
+                          });
+                        }}
+                      >
+                        <Zap size={12} className="mr-1" />
+                        Pay order
+                      </Button>
+                      {pendingOrderId && (
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          className="flex-1"
+                          disabled={cancelLoading}
+                          onClick={() =>
+                            cancelOrder({
+                              variables: {
+                                input: {
+                                  orderId: pendingOrderId,
+                                  cancellationReason:
+                                    OrderCancellationReason.UnableToPay,
+                                },
+                              },
+                            })
+                          }
+                        >
+                          {cancelLoading ? (
+                            <Loader2 size={12} className="animate-spin" />
+                          ) : (
+                            'Cancel order'
+                          )}
+                        </Button>
+                      )}
+                    </div>
+                  </>
+                ) : (
+                  <p className="text-[11px] text-yellow-500 font-medium">
+                    Magma order in progress.
+                    {pendingOrderStatus && (
+                      <span className="text-yellow-500/70">
+                        {' '}
+                        {pendingOrderStatus.replace(/_/g, ' ').toLowerCase()}
+                      </span>
+                    )}
+                    <br />
+                    {pendingOrderId && (
+                      <a
+                        href={`https://magma.amboss.tech/order/${pendingOrderId}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-[11px] text-yellow-500/70 hover:text-yellow-500 underline"
+                      >
+                        View order on Magma
+                      </a>
+                    )}
+                  </p>
+                )}
               </div>
             )}
 

--- a/src/client/src/layouts/sidebar/SidebarTrade.tsx
+++ b/src/client/src/layouts/sidebar/SidebarTrade.tsx
@@ -10,19 +10,36 @@ import {
   CheckCircle2,
   Circle,
   RefreshCw,
+  Copy,
+  Zap,
 } from 'lucide-react';
+import { QRCodeSVG } from 'qrcode.react';
 import { useQuery } from '@apollo/client';
+import { Link } from '@/components/link/Link';
 import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
 import { cn } from '@/lib/utils';
 import {
   useTradingState,
   useTradingDispatch,
 } from '../../context/TradingContext';
-import { TapTransactionType } from '../../graphql/types';
+import {
+  TapTransactionType,
+  OrderCancellationReason,
+} from '../../graphql/types';
 import { useGetTradeQuoteLazyQuery } from '../../graphql/queries/__generated__/getTradeQuote.generated';
 import { useExecuteTradeMutation } from '../../graphql/mutations/__generated__/executeTrade.generated';
 import { useSetupTradeCapacityMutation } from '../../graphql/mutations/__generated__/setupTradeCapacity.generated';
+import { useCancelMagmaOrderMutation } from '../../graphql/mutations/__generated__/cancelMagmaOrder.generated';
+import { useGetMagmaOrderInvoiceLazyQuery } from '../../graphql/queries/__generated__/getMagmaOrderInvoice.generated';
 import { GET_OFFER_READINESS } from '../../graphql/queries/getOfferReadiness';
+import { Pay } from '../../views/home/account/pay/Pay';
 import { getErrorContent } from '../../utils/error';
 import { formatNumber } from '../../utils/helpers';
 import {
@@ -126,6 +143,28 @@ export const SidebarTrade: FC<{ embedded?: boolean }> = ({
       onError: err => toast.error(getErrorContent(err)),
     });
 
+  const [cancelOrder, { loading: cancelLoading }] = useCancelMagmaOrderMutation(
+    {
+      onCompleted: data => {
+        if (data.magma.cancel_order.success) {
+          toast.success('Magma order cancelled');
+          refetchReadiness();
+        } else {
+          toast.error('Failed to cancel order');
+        }
+      },
+      onError: err => toast.error(getErrorContent(err)),
+    }
+  );
+
+  const [payDialogOpen, setPayDialogOpen] = useState(false);
+  const [
+    fetchInvoice,
+    { data: invoiceData, loading: invoiceLoading, reset: resetInvoice },
+  ] = useGetMagmaOrderInvoiceLazyQuery();
+  const payingInvoice =
+    invoiceData?.magma?.orders?.get_invoice?.invoice ?? null;
+
   const isAssetPurchase = txType === TapTransactionType.Purchase;
   const offerAsset = selectedOffer?.asset;
   const symbol = offerAsset?.symbol || selectedAsset?.symbol || '';
@@ -135,7 +174,7 @@ export const SidebarTrade: FC<{ embedded?: boolean }> = ({
   const hasRate = rateDisplay !== '0' || rateFull !== '0';
   const isValid = amount && Number(amount) > 0;
   const quoteExpired = secondsLeft != null && secondsLeft <= 0;
-  const loading = tradeLoading || setupLoading;
+  const loading = tradeLoading || setupLoading || cancelLoading;
 
   const atomicAmount = isValid ? displayToAtomic(amount, precision) : BigInt(0);
 
@@ -185,6 +224,7 @@ export const SidebarTrade: FC<{ embedded?: boolean }> = ({
   const hasAssetChannel = (assetCh?.open_count ?? 0) > 0;
   const hasAssetPending = (assetCh?.pending_count ?? 0) > 0;
   const hasPendingOrder = readiness?.has_pending_order ?? false;
+  const pendingOrderId = readiness?.pending_order_id ?? null;
   const onchainSats = Number(readiness?.onchain_balance_sats ?? '0');
   const onchainAsset = BigInt(readiness?.onchain_asset_balance ?? '0');
   const channelsReady = hasBtcChannel && hasAssetChannel;
@@ -443,11 +483,13 @@ export const SidebarTrade: FC<{ embedded?: boolean }> = ({
                     {!hasBtcChannel &&
                       (hasBtcPending || hasPendingOrder || setupLoading) && (
                         <span className="ml-auto text-yellow-500">
-                          {setupLoading
-                            ? 'Setting up...'
-                            : hasBtcPending
-                              ? 'Opening...'
-                              : 'Order in progress'}
+                          {setupLoading ? (
+                            'Setting up...'
+                          ) : hasBtcPending ? (
+                            'Opening...'
+                          ) : (
+                            <Link to="/magma">Order pending</Link>
+                          )}
                         </span>
                       )}
                   </div>
@@ -490,11 +532,13 @@ export const SidebarTrade: FC<{ embedded?: boolean }> = ({
                     {!hasAssetChannel &&
                       (hasAssetPending || hasPendingOrder || setupLoading) && (
                         <span className="ml-auto text-yellow-500">
-                          {setupLoading
-                            ? 'Setting up...'
-                            : hasAssetPending
-                              ? 'Opening...'
-                              : 'Order in progress'}
+                          {setupLoading ? (
+                            'Setting up...'
+                          ) : hasAssetPending ? (
+                            'Opening...'
+                          ) : (
+                            <Link to="/magma">Order pending</Link>
+                          )}
                         </span>
                       )}
                   </div>
@@ -528,6 +572,12 @@ export const SidebarTrade: FC<{ embedded?: boolean }> = ({
           {/* Trading capacity */}
           {channelsReady && (
             <div className="flex flex-col gap-1 rounded-md border border-border/60 bg-muted/20 px-3 py-2.5 text-xs">
+              {hasPendingOrder && (
+                <div className="flex items-center gap-1 text-[10px] text-yellow-500 pb-1.5 border-b border-border/40">
+                  <span>Unpaid Magma order pending —</span>
+                  <Link to="/magma">view</Link>
+                </div>
+              )}
               <div className="flex items-center justify-between mb-0.5">
                 <span className="text-[10px] font-medium text-muted-foreground/70 uppercase tracking-wider">
                   Capacity
@@ -838,7 +888,11 @@ export const SidebarTrade: FC<{ embedded?: boolean }> = ({
                   size="sm"
                   onClick={handleGetQuote}
                   disabled={
-                    quoteLoading || !isValid || !hasCapacity || exceedsCapacity
+                    quoteLoading ||
+                    !isValid ||
+                    !hasCapacity ||
+                    exceedsCapacity ||
+                    hasPendingOrder
                   }
                 >
                   {quoteLoading ? (
@@ -884,6 +938,56 @@ export const SidebarTrade: FC<{ embedded?: boolean }> = ({
               </Button>
             )}
 
+            {hasPendingOrder && (
+              <div className="mt-2 rounded-md border border-yellow-500/30 bg-yellow-500/10 p-2.5 space-y-2">
+                <p className="text-[11px] text-yellow-500 font-medium">
+                  An unpaid Magma order is blocking trading. Pay or cancel it to
+                  continue.
+                </p>
+                <div className="flex gap-2">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="flex-1 border-yellow-500/50 text-yellow-500 hover:bg-yellow-500/10"
+                    disabled={!pendingOrderId}
+                    onClick={() => {
+                      if (!pendingOrderId) return;
+                      setPayDialogOpen(true);
+                      fetchInvoice({ variables: { orderId: pendingOrderId } });
+                    }}
+                  >
+                    <Zap size={12} className="mr-1" />
+                    Pay order
+                  </Button>
+                  {pendingOrderId && (
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      className="flex-1"
+                      disabled={cancelLoading}
+                      onClick={() =>
+                        cancelOrder({
+                          variables: {
+                            input: {
+                              orderId: pendingOrderId,
+                              cancellationReason:
+                                OrderCancellationReason.UnableToPay,
+                            },
+                          },
+                        })
+                      }
+                    >
+                      {cancelLoading ? (
+                        <Loader2 size={12} className="animate-spin" />
+                      ) : (
+                        'Cancel order'
+                      )}
+                    </Button>
+                  )}
+                </div>
+              </div>
+            )}
+
             {quoteExpired && (
               <Button
                 variant="outline"
@@ -898,6 +1002,75 @@ export const SidebarTrade: FC<{ embedded?: boolean }> = ({
           </div>
         </>
       )}
+
+      <Dialog
+        open={payDialogOpen}
+        onOpenChange={open => {
+          if (!open) {
+            setPayDialogOpen(false);
+            resetInvoice();
+          }
+        }}
+      >
+        <DialogContent className="sm:max-w-xl">
+          <DialogHeader>
+            <DialogTitle>Pay Invoice</DialogTitle>
+            <DialogDescription>
+              Scan the QR code, copy the invoice, or pay directly.
+            </DialogDescription>
+          </DialogHeader>
+
+          {invoiceLoading && (
+            <div className="flex justify-center py-8">
+              <Loader2 className="animate-spin size-6 text-muted-foreground" />
+            </div>
+          )}
+
+          {!invoiceLoading && !payingInvoice && (
+            <p className="text-sm text-muted-foreground text-center py-4">
+              No invoice available for this order.
+            </p>
+          )}
+
+          {!invoiceLoading && payingInvoice && (
+            <div className="flex flex-col gap-4">
+              <div className="flex justify-center">
+                <div className="rounded border border-border bg-white p-3">
+                  <QRCodeSVG value={`lightning:${payingInvoice}`} size={200} />
+                </div>
+              </div>
+
+              <div className="flex flex-col items-center gap-2">
+                <div className="max-w-full break-all text-center font-mono text-[11px] text-muted-foreground">
+                  {payingInvoice}
+                </div>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() =>
+                    navigator.clipboard
+                      .writeText(payingInvoice)
+                      .then(() => toast.success('Copied to clipboard'))
+                      .catch(() => toast.error('Failed to copy to clipboard'))
+                  }
+                >
+                  <Copy size={14} className="mr-1" />
+                  Copy Invoice
+                </Button>
+              </div>
+
+              <Pay
+                predefinedRequest={payingInvoice}
+                payCallback={() => {
+                  setPayDialogOpen(false);
+                  resetInvoice();
+                  refetchReadiness();
+                }}
+              />
+            </div>
+          )}
+        </DialogContent>
+      </Dialog>
     </>
   );
 

--- a/src/client/src/layouts/sidebar/SidebarTrade.tsx
+++ b/src/client/src/layouts/sidebar/SidebarTrade.tsx
@@ -575,7 +575,14 @@ export const SidebarTrade: FC<{ embedded?: boolean }> = ({
               {hasPendingOrder && (
                 <div className="flex items-center gap-1 text-[10px] text-yellow-500 pb-1.5 border-b border-border/40">
                   <span>Unpaid Magma order pending —</span>
-                  <Link to="/magma">view</Link>
+                  <a
+                    href={`https://magma.amboss.tech/order/${pendingOrderId}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="underline"
+                  >
+                    view
+                  </a>
                 </div>
               )}
               <div className="flex items-center justify-between mb-0.5">
@@ -943,6 +950,17 @@ export const SidebarTrade: FC<{ embedded?: boolean }> = ({
                 <p className="text-[11px] text-yellow-500 font-medium">
                   An unpaid Magma order is blocking trading. Pay or cancel it to
                   continue.
+                  <br />
+                  {pendingOrderId && (
+                    <a
+                      href={`https://magma.amboss.tech/order/${pendingOrderId}`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-[11px] text-yellow-500/70 hover:text-yellow-500 underline"
+                    >
+                      View order on Magma
+                    </a>
+                  )}
                 </p>
                 <div className="flex gap-2">
                   <Button

--- a/src/server/modules/api/invoices/invoices.resolver.ts
+++ b/src/server/modules/api/invoices/invoices.resolver.ts
@@ -1,5 +1,6 @@
 import { Inject } from '@nestjs/common';
 import { Args, Mutation, Query, Resolver } from '@nestjs/graphql';
+import { GraphQLError } from 'graphql';
 import { WINSTON_MODULE_PROVIDER } from 'nest-winston';
 import { Logger } from 'winston';
 import { NodeService } from '../../node/node.service';
@@ -122,9 +123,18 @@ export class InvoicesResolver {
 
     this.logger.debug('Paying invoice with params', props);
 
-    const response = await this.nodeService.pay(user.id, props);
-
-    this.logger.debug('Paid invoice', response);
-    return true;
+    try {
+      const response = await this.nodeService.pay(user.id, props);
+      this.logger.debug('Paid invoice', response);
+      return true;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      if (msg === 'InsufficientBalanceToAttemptPayment') {
+        throw new GraphQLError(
+          'Payment failed: could not find a funded route. Check for inactive channels or stuck HTLCs.'
+        );
+      }
+      throw err;
+    }
   }
 }

--- a/src/server/modules/api/magma/magma.resolver.ts
+++ b/src/server/modules/api/magma/magma.resolver.ts
@@ -1015,7 +1015,8 @@ export class RailsQueriesResolver {
     const peers = peersResult[0]?.peers || [];
     const pendingChannels = pendingResult[0]?.pending_channels || [];
     const assetBalances = assetBalancesResult[0] || [];
-    const hasPendingOrder = ordersResult;
+    const { hasPending: hasPendingOrder, orderId: pendingOrderId } =
+      ordersResult;
     const chainBalance = chainBalanceResult[0]?.chain_balance ?? 0;
 
     // On-chain asset balance for the specific asset
@@ -1113,6 +1114,7 @@ export class RailsQueriesResolver {
         has_active_channel: matchingAssets.length > 0,
       },
       has_pending_order: hasPendingOrder,
+      pending_order_id: pendingOrderId,
       onchain_balance_sats: String(chainBalance),
       onchain_asset_balance: onchainAssetBalance.toString(),
     };
@@ -1121,19 +1123,12 @@ export class RailsQueriesResolver {
   private async fetchPendingOrdersForPeer(
     user: UserId,
     peerPubkey: string
-  ): Promise<boolean> {
+  ): Promise<{ hasPending: boolean; orderId?: string }> {
     try {
       const [ambossAuth, magmaUrl] = await Promise.all([
         this.ambossTokenService.getOrCreate(user),
         this.ambossService.resolveMagmaUrl(user),
       ]);
-
-      const pendingStatuses = [
-        'WAITING_FOR_CHANNEL_OPEN',
-        'WAITING_FOR_SELLER_APPROVAL',
-        'WAITING_FOR_PAYMENT',
-        'CHANNEL_OPENING',
-      ];
 
       const { data, error } = await this.fetchService.graphqlFetchWithProxy<{
         user: {
@@ -1151,18 +1146,19 @@ export class RailsQueriesResolver {
           page: { offset: 0, limit: 1 },
           input: {
             peer_pubkey: peerPubkey,
-            status: pendingStatuses,
+            action_needed: true,
           },
         },
         { authorization: `Bearer ${ambossAuth}` }
       );
 
-      if (error || !data?.user?.market?.orders) return false;
+      if (error || !data?.user?.market?.orders) return { hasPending: false };
 
       const { purchases, sales } = data.user.market.orders;
-      return purchases.total > 0 || sales.total > 0;
+      const match = purchases.list[0] || sales.list[0];
+      return { hasPending: !!match, orderId: match?.id };
     } catch {
-      return false;
+      return { hasPending: false };
     }
   }
 }

--- a/src/server/modules/api/magma/magma.resolver.ts
+++ b/src/server/modules/api/magma/magma.resolver.ts
@@ -815,6 +815,7 @@ export class RailsQueriesResolver {
           has_active_channel: false,
         },
         has_pending_order: false,
+        pending_order_status: null,
         onchain_balance_sats: '0',
         onchain_asset_balance: '0',
       };
@@ -1015,8 +1016,11 @@ export class RailsQueriesResolver {
     const peers = peersResult[0]?.peers || [];
     const pendingChannels = pendingResult[0]?.pending_channels || [];
     const assetBalances = assetBalancesResult[0] || [];
-    const { hasPending: hasPendingOrder, orderId: pendingOrderId } =
-      ordersResult;
+    const {
+      hasPending: hasPendingOrder,
+      orderId: pendingOrderId,
+      status: pendingOrderStatus,
+    } = ordersResult;
     const chainBalance = chainBalanceResult[0]?.chain_balance ?? 0;
 
     // On-chain asset balance for the specific asset
@@ -1115,6 +1119,7 @@ export class RailsQueriesResolver {
       },
       has_pending_order: hasPendingOrder,
       pending_order_id: pendingOrderId,
+      pending_order_status: pendingOrderStatus,
       onchain_balance_sats: String(chainBalance),
       onchain_asset_balance: onchainAssetBalance.toString(),
     };
@@ -1123,11 +1128,29 @@ export class RailsQueriesResolver {
   private async fetchPendingOrdersForPeer(
     user: UserId,
     peerPubkey: string
-  ): Promise<{ hasPending: boolean; orderId?: string }> {
+  ): Promise<{ hasPending: boolean; orderId?: string; status?: string }> {
     try {
       const [ambossAuth, magmaUrl] = await Promise.all([
         this.ambossTokenService.getOrCreate(user),
         this.ambossService.resolveMagmaUrl(user),
+      ]);
+
+      // Fetch recent orders for this peer without an action_needed filter:
+      // action_needed is role-scoped, so WAITING_FOR_CHANNEL_OPEN (seller's
+      // action) is excluded once the buyer has paid. We filter client-side
+      // for all non-terminal statuses instead.
+      const unpaidStatuses = new Set([
+        'WAITING_FOR_SELLER_APPROVAL',
+        'WAITING_FOR_BUYER_PAYMENT',
+      ]);
+      // Paid but channel not yet confirmed on-chain — show "in progress" notice.
+      // SELLER_OPENED_CHANNEL, VALID_CHANNEL_OPENING and
+      // CHANNEL_MONITORING_FINISHED mean the channel is already open and
+      // usable, so we don't surface any warning for those.
+      const inProgressStatuses = new Set([
+        'WAITING_FOR_CHANNEL_OPEN',
+        'SELLER_SENT_TRANSACTION',
+        'WAITING_FOR_ON_CHAIN_CONFIRMATION',
       ]);
 
       const { data, error } = await this.fetchService.graphqlFetchWithProxy<{
@@ -1155,8 +1178,29 @@ export class RailsQueriesResolver {
       if (error || !data?.user?.market?.orders) return { hasPending: false };
 
       const { purchases, sales } = data.user.market.orders;
-      const match = purchases.list[0] || sales.list[0];
-      return { hasPending: !!match, orderId: match?.id };
+      const allOrders = [...purchases.list, ...sales.list];
+
+      const unpaidMatch = allOrders.find(o => unpaidStatuses.has(o.status));
+      if (unpaidMatch) {
+        return {
+          hasPending: true,
+          orderId: unpaidMatch.id,
+          status: unpaidMatch.status,
+        };
+      }
+
+      const inProgressMatch = allOrders.find(o =>
+        inProgressStatuses.has(o.status)
+      );
+      if (inProgressMatch) {
+        return {
+          hasPending: false,
+          orderId: inProgressMatch.id,
+          status: inProgressMatch.status,
+        };
+      }
+
+      return { hasPending: false };
     } catch {
       return { hasPending: false };
     }

--- a/src/server/modules/api/trade/trade.types.ts
+++ b/src/server/modules/api/trade/trade.types.ts
@@ -284,6 +284,9 @@ export class OfferReadinessResult {
   @Field()
   has_pending_order: boolean;
 
+  @Field({ nullable: true })
+  pending_order_id?: string;
+
   @Field()
   onchain_balance_sats: string;
 

--- a/src/server/modules/api/trade/trade.types.ts
+++ b/src/server/modules/api/trade/trade.types.ts
@@ -287,6 +287,9 @@ export class OfferReadinessResult {
   @Field({ nullable: true })
   pending_order_id?: string;
 
+  @Field({ nullable: true })
+  pending_order_status?: string;
+
   @Field()
   onchain_balance_sats: string;
 


### PR DESCRIPTION
When a pending Magma order (WAITING_FOR_BUYER_PAYMENT) exists for a selected offer, the Get Quote button is disabled and a prominent yellow action block is shown with "Pay order" and "Cancel order" buttons so the user knows what to do next.

Disable `Get Quote` button when there is a pending Magma order