### PR TITLE
Handle channel-open timeout gracefully

### DIFF
--- a/schema.gql
+++ b/schema.gql
@@ -951,6 +951,7 @@ input SetupTradeCapacityInput {
 }
 
 type SetupTradeCapacityResult {
+  channelOpenPending: Boolean
   magmaOrderAmountAsset: String
   magmaOrderAmountSats: String
   magmaOrderFeeSats: String

--- a/src/client/src/graphql/mutations/__generated__/setupTradeCapacity.generated.tsx
+++ b/src/client/src/graphql/mutations/__generated__/setupTradeCapacity.generated.tsx
@@ -21,6 +21,7 @@ export type SetupTradeCapacityMutation = {
     outboundChannelOutputIndex?: number | null;
     skippedMagmaOrder?: boolean | null;
     skippedOutboundChannel?: boolean | null;
+    channelOpenPending?: boolean | null;
   };
 };
 
@@ -37,6 +38,7 @@ export const SetupTradeCapacityDocument = gql`
       outboundChannelOutputIndex
       skippedMagmaOrder
       skippedOutboundChannel
+      channelOpenPending
     }
   }
 `;

--- a/src/client/src/graphql/mutations/setupTradeCapacity.ts
+++ b/src/client/src/graphql/mutations/setupTradeCapacity.ts
@@ -13,6 +13,7 @@ export const SETUP_TRADE_CAPACITY = gql`
       outboundChannelOutputIndex
       skippedMagmaOrder
       skippedOutboundChannel
+      channelOpenPending
     }
   }
 `;

--- a/src/client/src/graphql/types.ts
+++ b/src/client/src/graphql/types.ts
@@ -1318,6 +1318,7 @@ export type SetupTradeCapacityInput = {
 
 export type SetupTradeCapacityResult = {
   __typename?: 'SetupTradeCapacityResult';
+  channelOpenPending?: Maybe<Scalars['Boolean']['output']>;
   magmaOrderAmountAsset?: Maybe<Scalars['String']['output']>;
   magmaOrderAmountSats?: Maybe<Scalars['String']['output']>;
   magmaOrderFeeSats?: Maybe<Scalars['String']['output']>;

--- a/src/client/src/layouts/sidebar/SidebarTrade.tsx
+++ b/src/client/src/layouts/sidebar/SidebarTrade.tsx
@@ -129,8 +129,9 @@ export const SidebarTrade: FC<{ embedded?: boolean }> = ({
       onCompleted: data => {
         const result = data.setupTradeCapacity;
         if (result.success) {
-          const msg =
-            result.skippedMagmaOrder && result.skippedOutboundChannel
+          const msg = result.channelOpenPending
+            ? 'Payment sent — inbound channel is being set up by the peer'
+            : result.skippedMagmaOrder && result.skippedOutboundChannel
               ? 'Capacity already sufficient'
               : result.skippedMagmaOrder || result.skippedOutboundChannel
                 ? 'Trade capacity increased successfully'
@@ -138,9 +139,13 @@ export const SidebarTrade: FC<{ embedded?: boolean }> = ({
           toast.success(msg);
           setAmount('');
           clearQuote();
+          refetchReadiness();
         }
       },
-      onError: err => toast.error(getErrorContent(err)),
+      onError: err => {
+        toast.error(getErrorContent(err));
+        refetchReadiness();
+      },
     });
 
   const [cancelOrder, { loading: cancelLoading }] = useCancelMagmaOrderMutation(

--- a/src/server/modules/api/magma/magma.resolver.spec.ts
+++ b/src/server/modules/api/magma/magma.resolver.spec.ts
@@ -611,15 +611,20 @@ describe('MagmaResolver', () => {
       ).rejects.toThrow('Failed to pay Magma invoice');
     });
 
-    it('rejects when inbound channel times out (outbound may have started in parallel)', async () => {
-      // waitForChannelFromPeer rejects (timeout) and pay never settles
+    it('resolves with channelOpenPending when inbound channel open times out', async () => {
+      // waitForChannelFromPeer rejects (timeout) — payment is in-flight so
+      // this is treated as success with channelOpenPending=true rather than
+      // an error, so the caller can show the right UI state.
       mockNodeService.waitForChannelFromPeer.mockRejectedValue(
         new Error('Timed out waiting for channel from peer')
       );
 
-      await expect(
-        setupResolver.setupTradeCapacity(userId, purchaseInput)
-      ).rejects.toThrow('Timed out waiting for channel from peer');
+      const result = await setupResolver.setupTradeCapacity(
+        userId,
+        purchaseInput
+      );
+      expect(result.success).toBe(true);
+      expect(result.channelOpenPending).toBe(true);
     });
 
     it('throws when asset amount is zero', async () => {

--- a/src/server/modules/api/magma/magma.resolver.ts
+++ b/src/server/modules/api/magma/magma.resolver.ts
@@ -431,14 +431,33 @@ export class MagmaResolver {
             });
           });
 
-          await Promise.race([
-            this.nodeService.waitForChannelFromPeer(
-              user.id,
-              input.swapNodePubkey,
-              120_000
-            ),
-            payFailureGuard,
-          ]);
+          let channelOpenPending = false;
+
+          try {
+            await Promise.race([
+              this.nodeService.waitForChannelFromPeer(
+                user.id,
+                input.swapNodePubkey,
+                120_000
+              ),
+              payFailureGuard,
+            ]);
+            this.logger.info('Magma channel opening detected', {
+              orderId: magmaOrder.id,
+            });
+          } catch (err) {
+            const msg = err instanceof Error ? err.message : String(err);
+            if (msg.includes('Timed out')) {
+              // Payment is in-flight; channel will open on Magma's schedule.
+              channelOpenPending = true;
+              this.logger.info(
+                'Timed out waiting for channel open — payment in-flight, channel will open eventually',
+                { orderId: magmaOrder.id }
+              );
+            } else {
+              throw err;
+            }
+          }
 
           // Suppress the now-detached payFailureGuard rejection and log the
           // eventual settlement outcome for observability.
@@ -456,9 +475,7 @@ export class MagmaResolver {
               );
             });
 
-          this.logger.info('Magma channel opening detected', {
-            orderId: magmaOrder.id,
-          });
+          return { channelOpenPending };
         },
       ],
 
@@ -561,6 +578,9 @@ export class MagmaResolver {
       skippedMagmaOrder: !result.magmaOrder || undefined,
       skippedOutboundChannel:
         (!!input.satsAmount && !result.outboundChannel) || undefined,
+      channelOpenPending:
+        (result.payMagma as { channelOpenPending?: boolean } | undefined)
+          ?.channelOpenPending || undefined,
     };
   }
 }
@@ -1166,11 +1186,8 @@ export class RailsQueriesResolver {
         magmaUrl,
         getOrdersQuery,
         {
-          page: { offset: 0, limit: 1 },
-          input: {
-            peer_pubkey: peerPubkey,
-            action_needed: true,
-          },
+          page: { offset: 0, limit: 10 },
+          input: { peer_pubkey: peerPubkey },
         },
         { authorization: `Bearer ${ambossAuth}` }
       );

--- a/src/server/modules/api/magma/magma.types.ts
+++ b/src/server/modules/api/magma/magma.types.ts
@@ -431,6 +431,10 @@ export class SetupTradeCapacityResult {
   /** True when the outbound channel open was skipped because outbound capacity already exists. */
   @Field({ nullable: true })
   skippedOutboundChannel?: boolean;
+
+  /** True when the Magma invoice was paid but the channel open was not yet detected (still in progress). */
+  @Field({ nullable: true })
+  channelOpenPending?: boolean;
 }
 
 export type ChannelStateInfo = {
@@ -461,7 +465,7 @@ export type SetupTradeCapacityAuto = {
         feeSats?: number;
       }
     | undefined;
-  payMagma: void;
+  payMagma: { channelOpenPending: boolean } | void;
   outboundChannel: { txid: string; outputIndex: number } | undefined;
 };
 


### PR DESCRIPTION
Three changes:
- setupTradeCapacity: catch the waitForChannelFromPeer timeout and return success with channelOpenPending=true instead of throwing; the payment is in-flight and the channel will open on Magma's schedule
- SidebarTrade: always refetchReadiness after setup (success or error) so the form reflects the actual order state; show a "channel being set up" toast when channelOpenPending is true
- fetchPendingOrdersForPeer: drop action_needed filter (role-scoped, excludes WAITING_FOR_CHANNEL_OPEN for buyers) and filter client-side against all non-terminal statuses so the pending indicator stays visible while Magma opens the channel