### PR TITLE
chore: correct instructions in `/node-setup` route [AMB-2557]

### DIFF
--- a/src/client/src/components/nodeManager/AddNodeForm.tsx
+++ b/src/client/src/components/nodeManager/AddNodeForm.tsx
@@ -1,6 +1,6 @@
-import { useState } from 'react';
+import { useState, ReactNode } from 'react';
 import toast from 'react-hot-toast';
-import { Loader2 } from 'lucide-react';
+import { Info, Loader2 } from 'lucide-react';
 import { getErrorContent } from '@/utils/error';
 import { AddNodeInput } from '@/graphql/types';
 import { useAddNodeMutation } from '@/graphql/mutations/__generated__/addNode.generated';
@@ -8,8 +8,61 @@ import { GetUserNodesDocument } from '@/graphql/queries/__generated__/getUserNod
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
 
 type NodeType = 'lnd' | 'litd';
+
+// shadcn TooltipContent is `inline-flex` with column gaps, so multi-child
+// content gets laid out as separate flex columns. Wrapping the body in a
+// single <p> keeps it as one flex item so text wraps normally.
+const FieldHint = ({ children }: { children: ReactNode }) => (
+  <Tooltip>
+    <TooltipTrigger asChild>
+      <button
+        type="button"
+        aria-label="More info"
+        className="inline-flex shrink-0 text-muted-foreground/60 hover:text-muted-foreground"
+      >
+        <Info size={12} />
+      </button>
+    </TooltipTrigger>
+    <TooltipContent>
+      <p className="max-w-65 text-left leading-snug">{children}</p>
+    </TooltipContent>
+  </Tooltip>
+);
+
+const Field = ({
+  id,
+  label,
+  hint,
+  children,
+}: {
+  id: string;
+  label: ReactNode;
+  hint: ReactNode;
+  children: ReactNode;
+}) => (
+  <div className="flex flex-col gap-1.5">
+    <label
+      htmlFor={id}
+      className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground"
+    >
+      {label}
+      <FieldHint>{hint}</FieldHint>
+    </label>
+    {children}
+  </div>
+);
+
+const macaroonHint = (type: NodeType) =>
+  type === 'litd'
+    ? 'LiTD nodes require a super admin macaroon. The regular admin macaroon will not authenticate against LiTD.'
+    : 'Paste your admin macaroon as hex or base64. If your node runs LiTD, switch the node type tab above. LiTD requires a super admin macaroon instead.';
 
 interface AddNodeFormProps {
   onNodeAdded: (slug: string) => void;
@@ -36,19 +89,16 @@ export const AddNodeForm = ({ onNodeAdded }: AddNodeFormProps) => {
   const handleSubmit = () => {
     if (!name || !socket || !macaroon || loading) return;
 
-    const connectionInput = {
-      socket,
-      macaroon,
-      cert: cert || undefined,
-    };
-
     const input: AddNodeInput = {
       name,
-      [type]: connectionInput,
+      [type]: { socket, macaroon, cert: cert || undefined },
     };
 
     addNode({ variables: { input } });
   };
+
+  const macaroonLabel =
+    type === 'litd' ? 'Super Admin Macaroon' : 'Admin Macaroon';
 
   return (
     <div className="flex flex-col gap-3">
@@ -67,13 +117,12 @@ export const AddNodeForm = ({ onNodeAdded }: AddNodeFormProps) => {
           </TabsList>
         </Tabs>
       </div>
-      <div className="flex flex-col gap-1.5">
-        <label
-          htmlFor="node-name"
-          className="text-xs font-medium text-muted-foreground"
-        >
-          Node Name
-        </label>
+
+      <Field
+        id="node-name"
+        label="Node Name"
+        hint="Pick a label for this node inside ThunderHub. It is only used in this dashboard and has no relation to the LND alias broadcast on the network."
+      >
         <Input
           id="node-name"
           autoFocus
@@ -81,50 +130,48 @@ export const AddNodeForm = ({ onNodeAdded }: AddNodeFormProps) => {
           value={name}
           onChange={e => setName(e.target.value)}
         />
-      </div>
-      <div className="flex flex-col gap-1.5">
-        <label
-          htmlFor="node-socket"
-          className="text-xs font-medium text-muted-foreground"
-        >
-          Socket
-        </label>
+      </Field>
+
+      <Field
+        id="node-socket"
+        label="Socket"
+        hint="Format is host:port. For Voltage nodes, use the API endpoint and gRPC port shown in the dashboard."
+      >
         <Input
           id="node-socket"
           placeholder="host:port"
           value={socket}
           onChange={e => setSocket(e.target.value)}
         />
-      </div>
-      <div className="flex flex-col gap-1.5">
-        <label
-          htmlFor="node-macaroon"
-          className="text-xs font-medium text-muted-foreground"
-        >
-          Admin Macaroon
-        </label>
+      </Field>
+
+      <Field id="node-macaroon" label={macaroonLabel} hint={macaroonHint(type)}>
         <Input
           id="node-macaroon"
           placeholder="Hex or base64 encoded"
           value={macaroon}
           onChange={e => setMacaroon(e.target.value)}
         />
-      </div>
-      <div className="flex flex-col gap-1.5">
-        <label
-          htmlFor="node-cert"
-          className="text-xs font-medium text-muted-foreground"
-        >
-          TLS Certificate{' '}
-          <span className="text-muted-foreground/60">(optional)</span>
-        </label>
+      </Field>
+
+      <Field
+        id="node-cert"
+        label={
+          <>
+            TLS Certificate{' '}
+            <span className="text-muted-foreground/60">(optional)</span>
+          </>
+        }
+        hint="Leave blank for Voltage nodes as they use a CA-signed certificate, so providing one here will cause the connection to fail."
+      >
         <Input
           id="node-cert"
           placeholder="Hex or base64 encoded"
           value={cert}
           onChange={e => setCert(e.target.value)}
         />
-      </div>
+      </Field>
+
       <Button
         disabled={!name || !socket || !macaroon || loading}
         onClick={handleSubmit}


### PR DESCRIPTION
When its a `litd` node

- admin macaroon doesnt work so it needs to tell users to paste a superadmin macaroon instead.
- tls cert is not optional if this is a voltage node, adding it throws error because voltage uses ca signed certificates, so we dont need to provide it
- for voltage nodes atleast, `host:port` from the connection string doesnt work, instead we 
need the `apiendpoint:grpcport` to make it work

<hr>

<img width="848" height="776" alt="image" src="https://github.com/user-attachments/assets/b1a3c1c6-5b1b-4066-a131-10d8a74629bf" />
