### PR TITLE
fix(transactions): format trade memo in invoice and payments cards

### DIFF
--- a/src/client/src/pages/TransactionsPage.tsx
+++ b/src/client/src/pages/TransactionsPage.tsx
@@ -24,6 +24,7 @@ import {
 } from '../graphql/queries/__generated__/getPayments.generated';
 import { Card, CardContent, CardFooter } from '@/components/ui/card';
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
+import { TradeDisplayMode } from '../views/transactions/tradeMemo';
 
 const TransactionsView = () => {
   const [activeTab, setActiveTab] = useState('invoices');
@@ -35,6 +36,7 @@ const TransactionsView = () => {
   const { publicKey } = useNodeInfo();
 
   const [settings] = useLocalStorage('transactionSettings', defaultSettings);
+  const tradeDisplayMode = settings.tradeDisplayMode as TradeDisplayMode;
 
   const invoiceQuery = useGetInvoicesQuery({
     notifyOnNetworkStatusChange: true,
@@ -118,6 +120,7 @@ const TransactionsView = () => {
         {filtered.map((i, index) => (
           <InvoiceCard
             invoice={i as any}
+            tradeDisplayMode={tradeDisplayMode}
             key={index}
             index={index + 1}
             setIndexOpen={setIndexOpen}
@@ -126,7 +129,7 @@ const TransactionsView = () => {
         ))}
       </div>
     );
-  }, [invoiceQuery.data, indexOpen, settings]);
+  }, [invoiceQuery.data, indexOpen, settings, tradeDisplayMode]);
 
   const renderPayments = useCallback(() => {
     const list = paymentQuery.data?.getPayments.payments || [];
@@ -166,6 +169,7 @@ const TransactionsView = () => {
         {filtered.map((i, index) => (
           <PaymentsCard
             payment={i}
+            tradeDisplayMode={tradeDisplayMode}
             key={index}
             index={index + 1}
             setIndexOpen={setIndexOpen}
@@ -174,7 +178,14 @@ const TransactionsView = () => {
         ))}
       </div>
     );
-  }, [paymentQuery.data, indexOpen, settings, publicKey, selfInvoices]);
+  }, [
+    paymentQuery.data,
+    indexOpen,
+    settings,
+    publicKey,
+    selfInvoices,
+    tradeDisplayMode,
+  ]);
 
   const isDisabled = useMemo(() => {
     if (activeTab === 'invoices') {

--- a/src/client/src/views/transactions/ComputedMarker.tsx
+++ b/src/client/src/views/transactions/ComputedMarker.tsx
@@ -10,12 +10,12 @@ export const ComputedMarker = () => (
   <TooltipProvider>
     <Tooltip>
       <TooltipTrigger asChild>
-        <span className="inline-flex shrink-0 cursor-help text-amber-600 dark:text-amber-400">
-          <Calculator size={12} />
+        <span className="inline-flex shrink-0 cursor-help text-muted-foreground/50">
+          <Calculator size={10} />
         </span>
       </TooltipTrigger>
       <TooltipContent side="top">
-        Computed by ThunderHub from the raw trade memo.
+        Parsed by ThunderHub from the raw description.
       </TooltipContent>
     </Tooltip>
   </TooltipProvider>

--- a/src/client/src/views/transactions/ComputedMarker.tsx
+++ b/src/client/src/views/transactions/ComputedMarker.tsx
@@ -1,0 +1,22 @@
+import { Calculator } from 'lucide-react';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
+
+export const ComputedMarker = () => (
+  <TooltipProvider>
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span className="inline-flex shrink-0 cursor-help text-amber-600 dark:text-amber-400">
+          <Calculator size={12} />
+        </span>
+      </TooltipTrigger>
+      <TooltipContent side="top">
+        Computed by ThunderHub from the raw trade memo.
+      </TooltipContent>
+    </Tooltip>
+  </TooltipProvider>
+);

--- a/src/client/src/views/transactions/InvoiceCard.tsx
+++ b/src/client/src/views/transactions/InvoiceCard.tsx
@@ -12,6 +12,7 @@ import {
 import { Badge } from '@/components/ui/badge';
 import { Separator } from '@/components/ui/separator';
 import { DetailTable, DetailRow } from './DetailTable';
+import { formatTradeMemo } from './tradeMemo';
 
 interface InvoiceCardProps {
   invoice: InvoiceType;
@@ -96,7 +97,10 @@ export const InvoiceCard = ({
     payments,
   } = invoice;
 
-  const texts = payments.map(p => p?.messages?.message).filter(Boolean);
+  const displayDescription = formatTradeMemo(description) || 'Invoice';
+  const texts = payments
+    .map(p => formatTradeMemo(p?.messages?.message))
+    .filter(Boolean);
   const hasMessages = !!texts.length;
   const isOpen = index === indexOpen;
 
@@ -116,7 +120,7 @@ export const InvoiceCard = ({
           </div>
           <div className="hidden sm:flex flex-1 min-w-0 items-center gap-2">
             <span className="font-medium text-sm truncate">
-              {description || 'Invoice'}
+              {displayDescription}
             </span>
             {hasMessages && (
               <MessageCircle size={14} className="text-primary shrink-0" />
@@ -136,7 +140,7 @@ export const InvoiceCard = ({
         </div>
         <div className="flex sm:hidden items-center gap-2 mt-1.5">
           <span className="text-xs truncate text-muted-foreground">
-            {description || 'Invoice'}
+            {displayDescription}
           </span>
           {hasMessages && (
             <MessageCircle size={12} className="text-primary shrink-0" />
@@ -164,9 +168,9 @@ export const InvoiceCard = ({
                     <DetailRow label="Peer">
                       <ChannelAlias id={p.in_channel} />
                     </DetailRow>
-                    {p.messages?.message && (
+                    {formatTradeMemo(p.messages?.message) && (
                       <DetailRow label="Message">
-                        {p.messages.message}
+                        {formatTradeMemo(p.messages?.message)}
                       </DetailRow>
                     )}
                   </DetailTable>

--- a/src/client/src/views/transactions/InvoiceCard.tsx
+++ b/src/client/src/views/transactions/InvoiceCard.tsx
@@ -177,6 +177,9 @@ export const InvoiceCard = ({
                   tradeDisplayMode
                 );
                 const messageDisplay = getTradeMemoDisplay(p.messages?.message);
+                const showRawMessage =
+                  tradeDisplayMode === 'computed' &&
+                  messageDisplay?.isTradeMemo;
 
                 return (
                   <div key={idx} className="rounded bg-muted/50 p-2">
@@ -197,6 +200,11 @@ export const InvoiceCard = ({
                           </div>
                         </DetailRow>
                       )}
+                      {showRawMessage && (
+                        <DetailRow label="Raw Message">
+                          {messageDisplay.raw}
+                        </DetailRow>
+                      )}
                     </DetailTable>
                   </div>
                 );
@@ -213,6 +221,12 @@ export const InvoiceCard = ({
                 </div>
               </DetailRow>
             )}
+            {tradeDisplayMode === 'computed' &&
+              descriptionDisplay?.isTradeMemo && (
+                <DetailRow label="Raw Description">
+                  {descriptionDisplay.raw}
+                </DetailRow>
+              )}
             {is_confirmed && confirmed_at && (
               <DetailRow label="Confirmed">
                 {`${getDateDif(confirmed_at)} ago (${getFormatDate(confirmed_at)})`}

--- a/src/client/src/views/transactions/InvoiceCard.tsx
+++ b/src/client/src/views/transactions/InvoiceCard.tsx
@@ -177,10 +177,6 @@ export const InvoiceCard = ({
                   tradeDisplayMode
                 );
                 const messageDisplay = getTradeMemoDisplay(p.messages?.message);
-                const showRawMessage =
-                  tradeDisplayMode === 'computed' &&
-                  messageDisplay?.isTradeMemo;
-
                 return (
                   <div key={idx} className="rounded bg-muted/50 p-2">
                     <DetailTable>
@@ -191,18 +187,17 @@ export const InvoiceCard = ({
                       <DetailRow label="Peer">
                         <ChannelAlias id={p.in_channel} />
                       </DetailRow>
-                      {message && (
-                        <DetailRow label="Message">
+                      {messageDisplay?.isTradeMemo && (
+                        <DetailRow label="Parsed Message">
                           <div className="inline-flex items-start gap-1">
-                            <span>{message}</span>
-                            {tradeDisplayMode === 'computed' &&
-                              messageDisplay?.isTradeMemo && <ComputedMarker />}
+                            <span>{messageDisplay.computed}</span>
+                            <ComputedMarker />
                           </div>
                         </DetailRow>
                       )}
-                      {showRawMessage && (
-                        <DetailRow label="Raw Message">
-                          {messageDisplay.raw}
+                      {message && (
+                        <DetailRow label="Message">
+                          {messageDisplay?.raw ?? message}
                         </DetailRow>
                       )}
                     </DetailTable>
@@ -212,21 +207,19 @@ export const InvoiceCard = ({
             </div>
           )}
           <DetailTable>
-            {descriptionDisplay && (
-              <DetailRow label="Description">
+            {descriptionDisplay?.isTradeMemo && (
+              <DetailRow label="Parsed Description">
                 <div className="inline-flex items-start gap-1">
-                  <span>{displayDescription}</span>
-                  {tradeDisplayMode === 'computed' &&
-                    descriptionDisplay.isTradeMemo && <ComputedMarker />}
+                  <span>{descriptionDisplay.computed}</span>
+                  <ComputedMarker />
                 </div>
               </DetailRow>
             )}
-            {tradeDisplayMode === 'computed' &&
-              descriptionDisplay?.isTradeMemo && (
-                <DetailRow label="Raw Description">
-                  {descriptionDisplay.raw}
-                </DetailRow>
-              )}
+            {descriptionDisplay && (
+              <DetailRow label="Description">
+                {descriptionDisplay.raw}
+              </DetailRow>
+            )}
             {is_confirmed && confirmed_at && (
               <DetailRow label="Confirmed">
                 {`${getDateDif(confirmed_at)} ago (${getFormatDate(confirmed_at)})`}

--- a/src/client/src/views/transactions/InvoiceCard.tsx
+++ b/src/client/src/views/transactions/InvoiceCard.tsx
@@ -12,10 +12,16 @@ import {
 import { Badge } from '@/components/ui/badge';
 import { Separator } from '@/components/ui/separator';
 import { DetailTable, DetailRow } from './DetailTable';
-import { formatTradeMemo } from './tradeMemo';
+import { ComputedMarker } from './ComputedMarker';
+import {
+  getTradeMemoDisplay,
+  getTradeMemoText,
+  TradeDisplayMode,
+} from './tradeMemo';
 
 interface InvoiceCardProps {
   invoice: InvoiceType;
+  tradeDisplayMode: TradeDisplayMode;
   index: number;
   setIndexOpen: (index: number) => void;
   indexOpen: number;
@@ -74,6 +80,7 @@ const StatusBadge = ({
 
 export const InvoiceCard = ({
   invoice,
+  tradeDisplayMode,
   index,
   setIndexOpen,
   indexOpen,
@@ -97,9 +104,11 @@ export const InvoiceCard = ({
     payments,
   } = invoice;
 
-  const displayDescription = formatTradeMemo(description) || 'Invoice';
+  const descriptionDisplay = getTradeMemoDisplay(description);
+  const displayDescription =
+    getTradeMemoText(description, tradeDisplayMode) || 'Invoice';
   const texts = payments
-    .map(p => formatTradeMemo(p?.messages?.message))
+    .map(p => getTradeMemoText(p?.messages?.message, tradeDisplayMode))
     .filter(Boolean);
   const hasMessages = !!texts.length;
   const isOpen = index === indexOpen;
@@ -122,6 +131,8 @@ export const InvoiceCard = ({
             <span className="font-medium text-sm truncate">
               {displayDescription}
             </span>
+            {tradeDisplayMode === 'computed' &&
+              descriptionDisplay?.isTradeMemo && <ComputedMarker />}
             {hasMessages && (
               <MessageCircle size={14} className="text-primary shrink-0" />
             )}
@@ -142,6 +153,8 @@ export const InvoiceCard = ({
           <span className="text-xs truncate text-muted-foreground">
             {displayDescription}
           </span>
+          {tradeDisplayMode === 'computed' &&
+            descriptionDisplay?.isTradeMemo && <ComputedMarker />}
           {hasMessages && (
             <MessageCircle size={12} className="text-primary shrink-0" />
           )}
@@ -158,27 +171,48 @@ export const InvoiceCard = ({
               <div className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
                 Payments
               </div>
-              {payments.map((p, idx) => (
-                <div key={idx} className="rounded bg-muted/50 p-2">
-                  <DetailTable>
-                    <DetailRow label="Amount">
-                      <Price amount={p.tokens} />
-                    </DetailRow>
-                    <DetailRow label="Channel">{p.in_channel}</DetailRow>
-                    <DetailRow label="Peer">
-                      <ChannelAlias id={p.in_channel} />
-                    </DetailRow>
-                    {formatTradeMemo(p.messages?.message) && (
-                      <DetailRow label="Message">
-                        {formatTradeMemo(p.messages?.message)}
+              {payments.map((p, idx) => {
+                const message = getTradeMemoText(
+                  p.messages?.message,
+                  tradeDisplayMode
+                );
+                const messageDisplay = getTradeMemoDisplay(p.messages?.message);
+
+                return (
+                  <div key={idx} className="rounded bg-muted/50 p-2">
+                    <DetailTable>
+                      <DetailRow label="Amount">
+                        <Price amount={p.tokens} />
                       </DetailRow>
-                    )}
-                  </DetailTable>
-                </div>
-              ))}
+                      <DetailRow label="Channel">{p.in_channel}</DetailRow>
+                      <DetailRow label="Peer">
+                        <ChannelAlias id={p.in_channel} />
+                      </DetailRow>
+                      {message && (
+                        <DetailRow label="Message">
+                          <div className="inline-flex items-start gap-1">
+                            <span>{message}</span>
+                            {tradeDisplayMode === 'computed' &&
+                              messageDisplay?.isTradeMemo && <ComputedMarker />}
+                          </div>
+                        </DetailRow>
+                      )}
+                    </DetailTable>
+                  </div>
+                );
+              })}
             </div>
           )}
           <DetailTable>
+            {descriptionDisplay && (
+              <DetailRow label="Description">
+                <div className="inline-flex items-start gap-1">
+                  <span>{displayDescription}</span>
+                  {tradeDisplayMode === 'computed' &&
+                    descriptionDisplay.isTradeMemo && <ComputedMarker />}
+                </div>
+              </DetailRow>
+            )}
             {is_confirmed && confirmed_at && (
               <DetailRow label="Confirmed">
                 {`${getDateDif(confirmed_at)} ago (${getFormatDate(confirmed_at)})`}

--- a/src/client/src/views/transactions/PaymentsCards.tsx
+++ b/src/client/src/views/transactions/PaymentsCards.tsx
@@ -160,21 +160,19 @@ export const PaymentsCard = ({
         <div className="px-3 pb-3">
           <Separator className="mb-3" />
           <DetailTable>
-            {description && (
-              <DetailRow label="Description">
+            {descriptionDisplay?.isTradeMemo && (
+              <DetailRow label="Parsed Description">
                 <div className="inline-flex items-start gap-1">
-                  <span>{description}</span>
-                  {tradeDisplayMode === 'computed' &&
-                    descriptionDisplay?.isTradeMemo && <ComputedMarker />}
+                  <span>{descriptionDisplay.computed}</span>
+                  <ComputedMarker />
                 </div>
               </DetailRow>
             )}
-            {tradeDisplayMode === 'computed' &&
-              descriptionDisplay?.isTradeMemo && (
-                <DetailRow label="Raw Description">
-                  {descriptionDisplay.raw}
-                </DetailRow>
-              )}
+            {description && (
+              <DetailRow label="Description">
+                {descriptionDisplay?.raw ?? description}
+              </DetailRow>
+            )}
             <DetailRow label="Created">
               {`${getDateDif(created_at)} ago (${getFormatDate(created_at)})`}
             </DetailRow>

--- a/src/client/src/views/transactions/PaymentsCards.tsx
+++ b/src/client/src/views/transactions/PaymentsCards.tsx
@@ -169,6 +169,12 @@ export const PaymentsCard = ({
                 </div>
               </DetailRow>
             )}
+            {tradeDisplayMode === 'computed' &&
+              descriptionDisplay?.isTradeMemo && (
+                <DetailRow label="Raw Description">
+                  {descriptionDisplay.raw}
+                </DetailRow>
+              )}
             <DetailRow label="Created">
               {`${getDateDif(created_at)} ago (${getFormatDate(created_at)})`}
             </DetailRow>

--- a/src/client/src/views/transactions/PaymentsCards.tsx
+++ b/src/client/src/views/transactions/PaymentsCards.tsx
@@ -11,6 +11,7 @@ import { Badge } from '@/components/ui/badge';
 import { Separator } from '@/components/ui/separator';
 import { decode } from 'light-bolt11-decoder';
 import { DetailTable, DetailRow } from './DetailTable';
+import { formatTradeMemo } from './tradeMemo';
 
 interface PaymentsCardProps {
   payment: PaymentType;
@@ -46,7 +47,7 @@ const decodeRequest = (request: string | null | undefined) => {
     const decoded = decode(request);
     const descSection = decoded.sections.find(s => s.name === 'description');
     if (descSection && 'value' in descSection && descSection.value) {
-      return descSection.value as string;
+      return formatTradeMemo(descSection.value as string);
     }
     return null;
   } catch {

--- a/src/client/src/views/transactions/PaymentsCards.tsx
+++ b/src/client/src/views/transactions/PaymentsCards.tsx
@@ -10,11 +10,17 @@ import { Price } from '../../components/price/Price';
 import { Badge } from '@/components/ui/badge';
 import { Separator } from '@/components/ui/separator';
 import { decode } from 'light-bolt11-decoder';
+import { ComputedMarker } from './ComputedMarker';
 import { DetailTable, DetailRow } from './DetailTable';
-import { formatTradeMemo } from './tradeMemo';
+import {
+  getTradeMemoDisplay,
+  getTradeMemoText,
+  TradeDisplayMode,
+} from './tradeMemo';
 
 interface PaymentsCardProps {
   payment: PaymentType;
+  tradeDisplayMode: TradeDisplayMode;
   index: number;
   setIndexOpen: (index: number) => void;
   indexOpen: number;
@@ -41,13 +47,16 @@ const StatusBadge = ({ confirmed }: { confirmed: boolean }) => {
   );
 };
 
-const decodeRequest = (request: string | null | undefined) => {
+const decodeRequest = (
+  request: string | null | undefined,
+  tradeDisplayMode: TradeDisplayMode
+) => {
   if (!request) return null;
   try {
     const decoded = decode(request);
     const descSection = decoded.sections.find(s => s.name === 'description');
     if (descSection && 'value' in descSection && descSection.value) {
-      return formatTradeMemo(descSection.value as string);
+      return getTradeMemoText(descSection.value as string, tradeDisplayMode);
     }
     return null;
   } catch {
@@ -57,6 +66,7 @@ const decodeRequest = (request: string | null | undefined) => {
 
 export const PaymentsCard = ({
   payment,
+  tradeDisplayMode,
   index,
   setIndexOpen,
   indexOpen,
@@ -81,7 +91,26 @@ export const PaymentsCard = ({
   const alias = destination_node?.node?.alias;
   const isOpen = index === indexOpen;
 
-  const description = useMemo(() => decodeRequest(request), [request]);
+  const description = useMemo(
+    () => decodeRequest(request, tradeDisplayMode),
+    [request, tradeDisplayMode]
+  );
+  const descriptionDisplay = useMemo(() => {
+    if (!request) return null;
+
+    try {
+      const decoded = decode(request);
+      const descSection = decoded.sections.find(s => s.name === 'description');
+
+      if (descSection && 'value' in descSection && descSection.value) {
+        return getTradeMemoDisplay(descSection.value as string);
+      }
+
+      return null;
+    } catch {
+      return null;
+    }
+  }, [request]);
 
   const handleClick = () => {
     setIndexOpen(isOpen ? 0 : index);
@@ -99,8 +128,10 @@ export const PaymentsCard = ({
           <div className="shrink-0">
             <StatusBadge confirmed={is_confirmed} />
           </div>
-          <div className="hidden sm:block flex-1 min-w-0">
-            <span className="font-medium text-sm truncate block">{title}</span>
+          <div className="hidden sm:flex flex-1 min-w-0 items-center gap-2">
+            <span className="font-medium text-sm truncate">{title}</span>
+            {tradeDisplayMode === 'computed' &&
+              descriptionDisplay?.isTradeMemo && <ComputedMarker />}
           </div>
           <span className="hidden sm:block text-xs text-muted-foreground shrink-0">
             {getDateDif(date)} ago
@@ -118,6 +149,8 @@ export const PaymentsCard = ({
           <span className="text-xs truncate text-muted-foreground">
             {title}
           </span>
+          {tradeDisplayMode === 'computed' &&
+            descriptionDisplay?.isTradeMemo && <ComputedMarker />}
           <span className="text-[11px] text-muted-foreground shrink-0 ml-auto">
             {getDateDif(date)} ago
           </span>
@@ -128,7 +161,13 @@ export const PaymentsCard = ({
           <Separator className="mb-3" />
           <DetailTable>
             {description && (
-              <DetailRow label="Description">{description}</DetailRow>
+              <DetailRow label="Description">
+                <div className="inline-flex items-start gap-1">
+                  <span>{description}</span>
+                  {tradeDisplayMode === 'computed' &&
+                    descriptionDisplay?.isTradeMemo && <ComputedMarker />}
+                </div>
+              </DetailRow>
             )}
             <DetailRow label="Created">
               {`${getDateDif(created_at)} ago (${getFormatDate(created_at)})`}

--- a/src/client/src/views/transactions/Settings.tsx
+++ b/src/client/src/views/transactions/Settings.tsx
@@ -23,7 +23,7 @@ export const TransactionSettings = () => {
         <div className="flex flex-col gap-0.5">
           <span className="text-xs font-medium">Trade Metadata</span>
           <span className="text-[11px] text-muted-foreground">
-            Switch between raw node memos and ThunderHub-computed labels
+            Switch between raw node memos and ThunderHub-parsed labels
           </span>
         </div>
         <ToggleGroup

--- a/src/client/src/views/transactions/Settings.tsx
+++ b/src/client/src/views/transactions/Settings.tsx
@@ -1,9 +1,12 @@
 import { Switch } from '@/components/ui/switch';
+import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
 import { useLocalStorage } from '../../hooks/UseLocalStorage';
+import { TradeDisplayMode } from './tradeMemo';
 
 export const defaultSettings = {
   rebalance: false,
   confirmed: true,
+  tradeDisplayMode: 'computed' as TradeDisplayMode,
 };
 
 export const TransactionSettings = () => {
@@ -12,10 +15,34 @@ export const TransactionSettings = () => {
     defaultSettings
   );
 
-  const { rebalance, confirmed } = settings;
+  const { rebalance, confirmed, tradeDisplayMode } = settings;
 
   return (
     <div className="flex flex-col gap-3">
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex flex-col gap-0.5">
+          <span className="text-xs font-medium">Trade Metadata</span>
+          <span className="text-[11px] text-muted-foreground">
+            Switch between raw node memos and ThunderHub-computed labels
+          </span>
+        </div>
+        <ToggleGroup
+          type="single"
+          variant="outline"
+          size="sm"
+          value={tradeDisplayMode}
+          onValueChange={value =>
+            value &&
+            setSettings({
+              ...settings,
+              tradeDisplayMode: value as TradeDisplayMode,
+            })
+          }
+        >
+          <ToggleGroupItem value="computed">Computed</ToggleGroupItem>
+          <ToggleGroupItem value="raw">Raw</ToggleGroupItem>
+        </ToggleGroup>
+      </div>
       <div className="flex items-center justify-between">
         <div className="flex flex-col gap-0.5">
           <span className="text-xs font-medium">Show Confirmed Only</span>

--- a/src/client/src/views/transactions/tradeMemo.ts
+++ b/src/client/src/views/transactions/tradeMemo.ts
@@ -2,11 +2,19 @@ import { formatNumber } from '../../utils/helpers';
 
 const TRADE_MEMO_PREFIX = 'th:trade:';
 
+export type TradeDisplayMode = 'computed' | 'raw';
+
 type TradeMemo = {
   t?: 'buy' | 'sell' | string;
   amt?: string;
   s?: string;
   p?: number;
+};
+
+export type TradeMemoDisplay = {
+  isTradeMemo: boolean;
+  raw: string;
+  computed: string;
 };
 
 const formatAssetAmount = (atomic?: string, precision?: number) => {
@@ -27,9 +35,7 @@ const formatAssetAmount = (atomic?: string, precision?: number) => {
   return formatNumber(atomic);
 };
 
-export const formatTradeMemo = (value?: string | null) => {
-  if (!value?.startsWith(TRADE_MEMO_PREFIX)) return value ?? null;
-
+const formatTradeMemo = (value: string) => {
   try {
     const parsed = JSON.parse(
       value.slice(TRADE_MEMO_PREFIX.length)
@@ -45,4 +51,34 @@ export const formatTradeMemo = (value?: string | null) => {
   } catch {
     return 'Trade';
   }
+};
+
+export const getTradeMemoDisplay = (
+  value?: string | null
+): TradeMemoDisplay | null => {
+  if (!value) return null;
+
+  if (!value.startsWith(TRADE_MEMO_PREFIX)) {
+    return {
+      isTradeMemo: false,
+      raw: value,
+      computed: value,
+    };
+  }
+
+  return {
+    isTradeMemo: true,
+    raw: value,
+    computed: formatTradeMemo(value),
+  };
+};
+
+export const getTradeMemoText = (
+  value: string | null | undefined,
+  mode: TradeDisplayMode
+) => {
+  const display = getTradeMemoDisplay(value);
+  if (!display) return null;
+
+  return mode === 'raw' ? display.raw : display.computed;
 };

--- a/src/client/src/views/transactions/tradeMemo.ts
+++ b/src/client/src/views/transactions/tradeMemo.ts
@@ -1,0 +1,48 @@
+import { formatNumber } from '../../utils/helpers';
+
+const TRADE_MEMO_PREFIX = 'th:trade:';
+
+type TradeMemo = {
+  t?: 'buy' | 'sell' | string;
+  amt?: string;
+  s?: string;
+  p?: number;
+};
+
+const formatAssetAmount = (atomic?: string, precision?: number) => {
+  if (!atomic) return null;
+
+  const numericPrecision = Number(precision ?? 0);
+  const value = Number(atomic);
+
+  if (!Number.isFinite(value)) return atomic;
+
+  if (numericPrecision > 0) {
+    return (value / 10 ** numericPrecision).toLocaleString('en-US', {
+      minimumFractionDigits: 2,
+      maximumFractionDigits: numericPrecision,
+    });
+  }
+
+  return formatNumber(atomic);
+};
+
+export const formatTradeMemo = (value?: string | null) => {
+  if (!value?.startsWith(TRADE_MEMO_PREFIX)) return value ?? null;
+
+  try {
+    const parsed = JSON.parse(
+      value.slice(TRADE_MEMO_PREFIX.length)
+    ) as TradeMemo;
+    const direction =
+      parsed.t === 'buy' ? 'Buy' : parsed.t === 'sell' ? 'Sell' : 'Trade';
+    const amount = formatAssetAmount(parsed.amt, parsed.p);
+    const symbol = parsed.s || 'asset';
+
+    return amount
+      ? `${direction} ${amount} ${symbol}`
+      : `${direction} ${symbol}`;
+  } catch {
+    return 'Trade';
+  }
+};


### PR DESCRIPTION
- Add formatTradeMemo helper to parse th:trade memo JSON
- Use formatted memo for invoice description and message rendering
- Apply formatTradeMemo to decoded payment request description

## now
<img width="3027" height="774" alt="image" src="https://github.com/user-attachments/assets/f474fe3a-eaf5-4e53-9f92-fc519b0501c1" />

## before
<img width="2538" height="841" alt="image" src="https://github.com/user-attachments/assets/db293290-1f23-4115-ab60-4cd955ae2fc1" />
