### PR TITLE
fix: set asset_id to null for SALE magma orders

### DIFF
--- a/src/client/tsconfig.json
+++ b/src/client/tsconfig.json
@@ -19,7 +19,7 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react-jsx",
-    "types": ["vite/client"]
+    "types": ["vite/client", "jest"]
   },
   "exclude": ["node_modules", "dist"],
   "include": ["**/*.ts", "**/*.tsx"]

--- a/src/server/modules/api/magma/magma.resolver.ts
+++ b/src/server/modules/api/magma/magma.resolver.ts
@@ -347,7 +347,10 @@ export class MagmaResolver {
                   size: magmaSize,
                   payment_method: 'SATS',
                   options: {
-                    asset_id: input.ambossAssetId,
+                    asset_id:
+                      input.transactionType === TapTransactionType.PURCHASE
+                        ? input.ambossAssetId
+                        : null,
                     private: true,
                   },
                 },


### PR DESCRIPTION
## Summary

- When placing a Magma order for a **SALE** (i.e. the user is selling an asset and needs to buy a BTC inbound channel), `options.asset_id` was incorrectly set to the asset's Amboss ID. Since the order is for a plain BTC channel, the field should be `null`.
- For **PURCHASE** orders (buying an asset channel), `options.asset_id` continues to be passed as before.

## Changes

- `src/server/modules/api/magma/magma.resolver.ts`: conditionally set `asset_id` to `null` when `transactionType === SALE`
- `src/client/tsconfig.json`: add `jest` to client TS types (minor housekeeping)

## Test plan

- [ ] Place a SALE order and confirm the Magma API receives `asset_id: null`
- [ ] Place a PURCHASE order and confirm `asset_id` is still populated correctly