### PR TITLE
fix: otplib migration error - change guardrails min secret bytes to 10

### DIFF
--- a/src/server/modules/api/auth/auth.resolver.ts
+++ b/src/server/modules/api/auth/auth.resolver.ts
@@ -11,7 +11,12 @@ import { appConstants } from 'src/server/utils/appConstants';
 import { NodeService } from '../../node/node.service';
 import { CurrentUser } from '../../security/security.decorators';
 import { UserId } from '../../security/security.types';
-import { generateSecret, generateURI, verifySync } from 'otplib';
+import {
+  createGuardrails,
+  generateSecret,
+  generateURI,
+  verifySync,
+} from 'otplib';
 import { shorten } from 'src/server/utils/string';
 import { TwofaResult } from './auth.types';
 
@@ -75,7 +80,14 @@ export class AuthResolver {
     }
 
     try {
-      const { valid } = verifySync({ token, secret, epochTolerance: 30 });
+      const { valid } = verifySync({
+        token,
+        secret,
+        epochTolerance: 30,
+        guardrails: createGuardrails({
+          MIN_SECRET_BYTES: 10,
+        }),
+      });
 
       if (!valid) {
         throw new Error('Invalid token');

--- a/src/server/modules/api/public/public.resolver.ts
+++ b/src/server/modules/api/public/public.resolver.ts
@@ -22,7 +22,7 @@ import { appConstants } from 'src/server/utils/appConstants';
 import { toWithError } from 'src/server/utils/async';
 import { decodeMacaroon, isCorrectPassword } from 'src/server/utils/crypto';
 import { AUTH_PREFIX, AuthType } from '../../security/security.types';
-import { verifySync } from 'otplib';
+import { createGuardrails, verifySync } from 'otplib';
 import { CreateInitialUserResult, PublicMutation } from './public.types';
 
 @Resolver(() => PublicMutation)
@@ -255,6 +255,9 @@ export class PublicResolver {
           token,
           secret: account.twofaSecret,
           epochTolerance: 30,
+          guardrails: createGuardrails({
+            MIN_SECRET_BYTES: 10,
+          }),
         });
         if (!valid) {
           throw new Error('token not valid');


### PR DESCRIPTION
Resolves #658:

> [SecretTooShortError]: Secret must be at least 16 bytes (128 bits), got 10 bytes

This error was introduced for previous instances when updating otplib from v12 to v13.

For context, see:

- https://github.com/yeojz/otplib/issues/671#issuecomment-4368647105