### PR TITLE
fix(ci): increase docker release timeout duration

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   docker:
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 120
     strategy:
       matrix:
         include:


### PR DESCRIPTION
fixes https://github.com/apotdevin/thunderhub/issues/755

The last job which failed, see here: https://github.com/apotdevin/thunderhub/actions/runs/23515202182/job/68445848418
on the `0.15.5` standard ran 60 min and was killed by the 1 hr limit.
Typical warm cache run is 13 min. Cold-cache + QEMU arm64 emulation occasionally blows past 60. Doubling the cap is the smallest change that unblocks this currently.
If cold builds become routine we can revisit native arm runners later.

<img width="2589" height="813" alt="image" src="https://github.com/user-attachments/assets/b181dbc4-4fa0-47f1-8950-2e8edf9275a3" />
