### PR TITLE
fix(assets): add native display formatting to trading distribution view [AMB-2611]

### DIFF
--- a/src/client/src/lib/formatNativeAsset.ts
+++ b/src/client/src/lib/formatNativeAsset.ts
@@ -1,0 +1,10 @@
+export const formatNativeAsset = (balance: number, symbol: string) => {
+  const formatted =
+    balance % 1 === 0
+      ? balance.toLocaleString()
+      : balance.toLocaleString(undefined, {
+          minimumFractionDigits: 2,
+          maximumFractionDigits: 2,
+        });
+  return `${formatted} ${symbol}`;
+};

--- a/src/client/src/views/assets/TradingDistribution.tsx
+++ b/src/client/src/views/assets/TradingDistribution.tsx
@@ -23,6 +23,7 @@ type Slice = {
   sats: number;
   pct: number;
   color: string;
+  nativeDisplay?: string;
 };
 
 const formatSats = (sats: number): string => {
@@ -104,7 +105,7 @@ export const TradingDistribution: FC = () => {
     // asset sats value = (assetUsdValue / btcPriceUsd) * 1e8
     const satsPerUsd = 1e8 / btcPriceUsd;
 
-    const items: { name: string; sats: number }[] = [];
+    const items: { name: string; sats: number; nativeDisplay?: string }[] = [];
     if (btcTotalSats > 0) {
       items.push({ name: 'BTC', sats: btcTotalSats });
     }
@@ -118,7 +119,18 @@ export const TradingDistribution: FC = () => {
           : rawBalance;
       const assetSats = displayBalance * info.usdPrice * satsPerUsd;
       if (assetSats > 0) {
-        items.push({ name: info.symbol, sats: assetSats });
+        const formatted =
+          displayBalance % 1 === 0
+            ? displayBalance.toLocaleString()
+            : displayBalance.toLocaleString(undefined, {
+                minimumFractionDigits: 2,
+                maximumFractionDigits: 2,
+              });
+        items.push({
+          name: info.symbol,
+          sats: assetSats,
+          nativeDisplay: `${formatted} ${info.symbol}`,
+        });
       }
     }
 
@@ -132,6 +144,7 @@ export const TradingDistribution: FC = () => {
         sats: item.sats,
         pct: (item.sats / totalSats) * 100,
         color: COLORS[i % COLORS.length],
+        nativeDisplay: item.nativeDisplay,
       }));
   }, [balancesData, channelData, btcTotalSats, btcPriceUsd, supportedData]);
 
@@ -184,7 +197,7 @@ export const TradingDistribution: FC = () => {
             <div className={`w-2.5 h-2.5 rounded-sm shrink-0 ${s.color}`} />
             <span className="text-xs truncate">{s.name}</span>
             <span className="text-xs tabular-nums text-muted-foreground">
-              {s.pct.toFixed(1)}% · {formatSats(s.sats)}
+              {s.pct.toFixed(1)}% · {s.nativeDisplay || formatSats(s.sats)}
             </span>
           </div>
         ))}

--- a/src/client/src/views/assets/TradingDistribution.tsx
+++ b/src/client/src/views/assets/TradingDistribution.tsx
@@ -6,6 +6,7 @@ import { useGetNodeBalancesQuery } from '../../graphql/queries/__generated__/get
 import { useGetTapSupportedAssetsQuery } from '../../graphql/queries/__generated__/getTapSupportedAssets.generated';
 import { usePriceState } from '../../context/PriceContext';
 import { TapBalanceGroupBy } from '../../graphql/types';
+import { formatNativeAsset } from '@/lib/formatNativeAsset';
 
 const COLORS = [
   'bg-orange-500',
@@ -119,17 +120,10 @@ export const TradingDistribution: FC = () => {
           : rawBalance;
       const assetSats = displayBalance * info.usdPrice * satsPerUsd;
       if (assetSats > 0) {
-        const formatted =
-          displayBalance % 1 === 0
-            ? displayBalance.toLocaleString()
-            : displayBalance.toLocaleString(undefined, {
-                minimumFractionDigits: 2,
-                maximumFractionDigits: 2,
-              });
         items.push({
           name: info.symbol,
           sats: assetSats,
-          nativeDisplay: `${formatted} ${info.symbol}`,
+          nativeDisplay: formatNativeAsset(displayBalance, info.symbol),
         });
       }
     }


### PR DESCRIPTION
<img width="1134" height="282" alt="image" src="https://github.com/user-attachments/assets/0785445a-4233-4256-874e-476580fd4b22" />

Just a cosmetic change, the percentage calculation remains unchanged and is still based on sats equivalent values like before