### PR TITLE
fix(magma): add referrer and verify seller asset-channel support [AMB-2708]

### DIFF
--- a/src/client/src/App.tsx
+++ b/src/client/src/App.tsx
@@ -27,6 +27,7 @@ import { Navigation } from './layouts/navigation/Navigation';
 import { RightSidebar } from './layouts/sidebar/RightSidebar';
 import { TradingProvider } from './context/TradingContext';
 import { NodeSlugProvider } from './hooks/useNodeSlug';
+import { RequireTapd } from './components/RequireTapd';
 import 'react-grid-layout/css/styles.css';
 import 'react-resizable/css/styles.css';
 
@@ -238,12 +239,54 @@ const AUTHENTICATED_ROUTES = (
       }
     />
     <Route path="amboss" element={<AmbossPage />} />
-    <Route path="assets" element={<AssetsPage />} />
-    <Route path="asset-channels" element={<AssetChannelsPage />} />
-    <Route path="asset-channels/pending" element={<AssetChannelsPage />} />
-    <Route path="asset-transactions" element={<AssetTransactionsPage />} />
-    <Route path="asset-tools" element={<AssetToolsPage />} />
-    <Route path="trading" element={<TradingPage />} />
+    <Route
+      path="assets"
+      element={
+        <RequireTapd>
+          <AssetsPage />
+        </RequireTapd>
+      }
+    />
+    <Route
+      path="asset-channels"
+      element={
+        <RequireTapd>
+          <AssetChannelsPage />
+        </RequireTapd>
+      }
+    />
+    <Route
+      path="asset-channels/pending"
+      element={
+        <RequireTapd>
+          <AssetChannelsPage />
+        </RequireTapd>
+      }
+    />
+    <Route
+      path="asset-transactions"
+      element={
+        <RequireTapd>
+          <AssetTransactionsPage />
+        </RequireTapd>
+      }
+    />
+    <Route
+      path="asset-tools"
+      element={
+        <RequireTapd>
+          <AssetToolsPage />
+        </RequireTapd>
+      }
+    />
+    <Route
+      path="trading"
+      element={
+        <RequireTapd>
+          <TradingPage />
+        </RequireTapd>
+      }
+    />
     <Route path="magma" element={<MagmaPage />} />
     <Route path="magma/sales" element={<MagmaPage />} />
     <Route path="*" element={<Navigate to="home" replace />} />

--- a/src/client/src/components/RequireTapd.tsx
+++ b/src/client/src/components/RequireTapd.tsx
@@ -1,0 +1,20 @@
+import { FC, ReactNode } from 'react';
+import { Navigate } from 'react-router-dom';
+import { useNodeSlug } from '../hooks/useNodeSlug';
+import { useTapdAvailable } from '../hooks/useTapdAvailable';
+
+/**
+ * Route guard for Taproot Assets pages. A node without the Taproot Assets
+ * capability cannot use these features, so direct navigation (typed URL or
+ * bookmark) is redirected to home — mirroring the hidden navigation section.
+ * Rendering is held until the capability query resolves to avoid a false
+ * redirect on first load.
+ */
+export const RequireTapd: FC<{ children: ReactNode }> = ({ children }) => {
+  const { available, loading } = useTapdAvailable();
+  const { buildPath } = useNodeSlug();
+
+  if (loading) return null;
+  if (!available) return <Navigate to={buildPath('home')} replace />;
+  return <>{children}</>;
+};

--- a/src/client/src/hooks/useTapdAvailable.tsx
+++ b/src/client/src/hooks/useTapdAvailable.tsx
@@ -1,0 +1,21 @@
+import { useGetNodeCapabilitiesQuery } from '../graphql/queries/__generated__/getNodeCapabilities.generated';
+
+/**
+ * Whether the active node exposes the Taproot Assets capability. Asset features
+ * (trading, asset channels, minting, etc.) require it, so this single signal
+ * gates both the navigation section and the asset routes — keeping link
+ * visibility and route access consistent.
+ *
+ * Note: this is the node's declared capability. The authoritative check that a
+ * tapd daemon is actually reachable lives server-side (`tapdNodeService.getInfo`
+ * in `setupTradeCapacity`), which blocks orders from a misconfigured node.
+ */
+export const useTapdAvailable = (): {
+  available: boolean;
+  loading: boolean;
+} => {
+  const { data, loading } = useGetNodeCapabilitiesQuery();
+  const available =
+    data?.node?.capabilities?.list?.includes('taproot_assets') ?? false;
+  return { available, loading };
+};

--- a/src/client/src/layouts/navigation/Navigation.tsx
+++ b/src/client/src/layouts/navigation/Navigation.tsx
@@ -26,7 +26,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from '../../components/ui/tooltip';
-import { useGetNodeCapabilitiesQuery } from '../../graphql/queries/__generated__/getNodeCapabilities.generated';
+import { useTapdAvailable } from '../../hooks/useTapdAvailable';
 import { Badge } from '../../components/ui/badge';
 import { SideSettings } from './sideSettings/SideSettings';
 import { LITD_SETUP_DOCS_URL } from '../../utils/externalLinks';
@@ -141,9 +141,7 @@ export const Navigation = ({ isBurger, setOpen }: NavigationProps) => {
   const nodePath = useNodePath();
   const { sidebar } = useConfigState();
 
-  const { data: capData } = useGetNodeCapabilitiesQuery();
-  const tapdAvailable =
-    capData?.node?.capabilities?.list?.includes('taproot_assets') ?? false;
+  const { available: tapdAvailable } = useTapdAvailable();
 
   const sections: NavSection[] = [
     AMBOSS_SECTION,

--- a/src/server/modules/api/magma/magma.gql.ts
+++ b/src/server/modules/api/magma/magma.gql.ts
@@ -1,5 +1,15 @@
 import gql from 'graphql-tag';
 
+/**
+ * Identifies ThunderHub as the source of a Magma order. Passed as the
+ * `referrer` on every order so Amboss can attribute the order to ThunderHub
+ * and avoid double-counting liquidity orders.
+ *
+ * NOTE: requires the Amboss `CreateManualOrderInput` schema to accept a
+ * `referrer` field — coordinate deployment with the Rails/API change.
+ */
+export const MAGMA_ORDER_REFERRER = 'thunderhub';
+
 export const getOffersQuery = gql`
   query GetOffers($input: OfferInput!) {
     public {

--- a/src/server/modules/api/magma/magma.resolver.spec.ts
+++ b/src/server/modules/api/magma/magma.resolver.spec.ts
@@ -300,6 +300,7 @@ describe('MagmaResolver', () => {
     const mockTapdNodeService = {
       fundAssetChannel: jest.fn(),
       getAssetChannelBalances: jest.fn(),
+      getInfo: jest.fn(),
     };
 
     let setupResolver: MagmaResolver;
@@ -321,40 +322,6 @@ describe('MagmaResolver', () => {
       error: undefined,
     });
 
-    // Offer the seller-compatibility check (assertOfferSupportsAssetChannels)
-    // re-fetches before placing an asset-channel order. Matches purchaseInput.
-    const offersResponse = (list?: unknown[]) => ({
-      data: {
-        public: {
-          offers: {
-            list: list ?? [
-              {
-                id: 'offer-1',
-                magma_offer_id: 'offer-1',
-                node: { pubkey: swapPubkey },
-                asset: {
-                  id: 'marketplace-asset-1',
-                  taproot_asset_details: {
-                    asset_id: 'deadbeef'.repeat(8),
-                    group_key: 'cafebabe'.repeat(8),
-                  },
-                },
-              },
-            ],
-            total_count: 1,
-          },
-        },
-      },
-      error: undefined,
-    });
-
-    // Route fetches by URL: the trade URL serves offers (compatibility check),
-    // the Magma URL serves order creation.
-    const routeFetch = (orderResponse = magmaOrderResponse()) =>
-      mockFetchService.graphqlFetchWithProxy.mockImplementation((url: string) =>
-        Promise.resolve(url === tradeUrl ? offersResponse() : orderResponse)
-      );
-
     beforeEach(() => {
       jest.clearAllMocks();
 
@@ -375,13 +342,17 @@ describe('MagmaResolver', () => {
         pending_channels: [],
       });
       mockTapdNodeService.getAssetChannelBalances.mockResolvedValue([]);
+      // Buyer node has a reachable Taproot Assets daemon by default.
+      mockTapdNodeService.getInfo.mockResolvedValue({ version: '1.0' });
 
       mockTapdNodeService.fundAssetChannel.mockResolvedValue({
         txid: 'asset-txid',
         outputIndex: 1,
       });
 
-      routeFetch();
+      mockFetchService.graphqlFetchWithProxy.mockResolvedValue(
+        magmaOrderResponse()
+      );
 
       mockAmbossService.resolveMagmaUrl.mockResolvedValue(magmaUrl);
       mockAmbossService.resolveTradeUrl.mockResolvedValue(tradeUrl);
@@ -621,7 +592,10 @@ describe('MagmaResolver', () => {
     // ── Error cases ──
 
     it('throws when Magma order creation fails', async () => {
-      routeFetch({ data: undefined, error: new Error('service unavailable') });
+      mockFetchService.graphqlFetchWithProxy.mockResolvedValue({
+        data: undefined,
+        error: new Error('service unavailable'),
+      });
 
       await expect(
         setupResolver.setupTradeCapacity(userId, purchaseInput)
@@ -665,9 +639,9 @@ describe('MagmaResolver', () => {
       ).rejects.toThrow('Asset amount must be greater than zero');
     });
 
-    // ── Seller asset-channel compatibility (PURCHASE) ──
+    // ── Buyer asset-channel capability ──
 
-    it('PURCHASE: tags the Magma order with the thunderhub referrer', async () => {
+    it('tags the Magma order with the thunderhub referrer', async () => {
       await setupResolver.setupTradeCapacity(userId, purchaseInput);
 
       expect(mockFetchService.graphqlFetchWithProxy).toHaveBeenCalledWith(
@@ -680,65 +654,29 @@ describe('MagmaResolver', () => {
       );
     });
 
-    it('PURCHASE: rejects when the seller offer is not found', async () => {
-      mockFetchService.graphqlFetchWithProxy.mockImplementation((url: string) =>
-        Promise.resolve(
-          url === tradeUrl ? offersResponse([]) : magmaOrderResponse()
-        )
+    it('rejects when the buyer node has no reachable Taproot Assets daemon', async () => {
+      mockTapdNodeService.getInfo.mockRejectedValue(
+        new Error('tapd unreachable')
       );
 
       await expect(
         setupResolver.setupTradeCapacity(userId, purchaseInput)
       ).rejects.toThrow('does not support asset channels');
 
-      // Order is never placed against the incompatible seller.
+      // No order is placed and no invoice is paid from an incapable node.
+      expect(mockFetchService.graphqlFetchWithProxy).not.toHaveBeenCalled();
       expect(mockNodeService.pay).not.toHaveBeenCalled();
     });
 
-    it('PURCHASE: rejects when the seller offer has no taproot asset details', async () => {
-      mockFetchService.graphqlFetchWithProxy.mockImplementation((url: string) =>
-        Promise.resolve(
-          url === tradeUrl
-            ? offersResponse([
-                {
-                  id: 'offer-1',
-                  magma_offer_id: 'offer-1',
-                  node: { pubkey: swapPubkey },
-                  asset: { id: 'marketplace-asset-1' },
-                },
-              ])
-            : magmaOrderResponse()
-        )
+    it('rejects a SALE too when the buyer node has no Taproot Assets daemon', async () => {
+      mockTapdNodeService.getInfo.mockRejectedValue(
+        new Error('tapd unreachable')
       );
 
       await expect(
-        setupResolver.setupTradeCapacity(userId, purchaseInput)
+        setupResolver.setupTradeCapacity(userId, saleInput)
       ).rejects.toThrow('does not support asset channels');
-      expect(mockNodeService.pay).not.toHaveBeenCalled();
-    });
-
-    it('PURCHASE: rejects when the offer belongs to a different seller node', async () => {
-      mockFetchService.graphqlFetchWithProxy.mockImplementation((url: string) =>
-        Promise.resolve(
-          url === tradeUrl
-            ? offersResponse([
-                {
-                  id: 'offer-1',
-                  magma_offer_id: 'offer-1',
-                  node: { pubkey: 'ef'.repeat(33) },
-                  asset: {
-                    id: 'marketplace-asset-1',
-                    taproot_asset_details: { asset_id: 'deadbeef'.repeat(8) },
-                  },
-                },
-              ])
-            : magmaOrderResponse()
-        )
-      );
-
-      await expect(
-        setupResolver.setupTradeCapacity(userId, purchaseInput)
-      ).rejects.toThrow('does not support asset channels');
+      expect(mockTapdNodeService.fundAssetChannel).not.toHaveBeenCalled();
     });
 
     // ── Idempotency: skip steps when capacity already exists ──

--- a/src/server/modules/api/magma/magma.resolver.spec.ts
+++ b/src/server/modules/api/magma/magma.resolver.spec.ts
@@ -321,6 +321,40 @@ describe('MagmaResolver', () => {
       error: undefined,
     });
 
+    // Offer the seller-compatibility check (assertOfferSupportsAssetChannels)
+    // re-fetches before placing an asset-channel order. Matches purchaseInput.
+    const offersResponse = (list?: unknown[]) => ({
+      data: {
+        public: {
+          offers: {
+            list: list ?? [
+              {
+                id: 'offer-1',
+                magma_offer_id: 'offer-1',
+                node: { pubkey: swapPubkey },
+                asset: {
+                  id: 'marketplace-asset-1',
+                  taproot_asset_details: {
+                    asset_id: 'deadbeef'.repeat(8),
+                    group_key: 'cafebabe'.repeat(8),
+                  },
+                },
+              },
+            ],
+            total_count: 1,
+          },
+        },
+      },
+      error: undefined,
+    });
+
+    // Route fetches by URL: the trade URL serves offers (compatibility check),
+    // the Magma URL serves order creation.
+    const routeFetch = (orderResponse = magmaOrderResponse()) =>
+      mockFetchService.graphqlFetchWithProxy.mockImplementation((url: string) =>
+        Promise.resolve(url === tradeUrl ? offersResponse() : orderResponse)
+      );
+
     beforeEach(() => {
       jest.clearAllMocks();
 
@@ -347,9 +381,7 @@ describe('MagmaResolver', () => {
         outputIndex: 1,
       });
 
-      mockFetchService.graphqlFetchWithProxy.mockResolvedValue(
-        magmaOrderResponse()
-      );
+      routeFetch();
 
       mockAmbossService.resolveMagmaUrl.mockResolvedValue(magmaUrl);
       mockAmbossService.resolveTradeUrl.mockResolvedValue(tradeUrl);
@@ -589,10 +621,7 @@ describe('MagmaResolver', () => {
     // ── Error cases ──
 
     it('throws when Magma order creation fails', async () => {
-      mockFetchService.graphqlFetchWithProxy.mockResolvedValue({
-        data: undefined,
-        error: new Error('service unavailable'),
-      });
+      routeFetch({ data: undefined, error: new Error('service unavailable') });
 
       await expect(
         setupResolver.setupTradeCapacity(userId, purchaseInput)
@@ -634,6 +663,82 @@ describe('MagmaResolver', () => {
           assetAmount: '0',
         })
       ).rejects.toThrow('Asset amount must be greater than zero');
+    });
+
+    // ── Seller asset-channel compatibility (PURCHASE) ──
+
+    it('PURCHASE: tags the Magma order with the thunderhub referrer', async () => {
+      await setupResolver.setupTradeCapacity(userId, purchaseInput);
+
+      expect(mockFetchService.graphqlFetchWithProxy).toHaveBeenCalledWith(
+        magmaUrl,
+        expect.anything(),
+        expect.objectContaining({
+          input: expect.objectContaining({ referrer: 'thunderhub' }),
+        }),
+        expect.any(Object)
+      );
+    });
+
+    it('PURCHASE: rejects when the seller offer is not found', async () => {
+      mockFetchService.graphqlFetchWithProxy.mockImplementation((url: string) =>
+        Promise.resolve(
+          url === tradeUrl ? offersResponse([]) : magmaOrderResponse()
+        )
+      );
+
+      await expect(
+        setupResolver.setupTradeCapacity(userId, purchaseInput)
+      ).rejects.toThrow('does not support asset channels');
+
+      // Order is never placed against the incompatible seller.
+      expect(mockNodeService.pay).not.toHaveBeenCalled();
+    });
+
+    it('PURCHASE: rejects when the seller offer has no taproot asset details', async () => {
+      mockFetchService.graphqlFetchWithProxy.mockImplementation((url: string) =>
+        Promise.resolve(
+          url === tradeUrl
+            ? offersResponse([
+                {
+                  id: 'offer-1',
+                  magma_offer_id: 'offer-1',
+                  node: { pubkey: swapPubkey },
+                  asset: { id: 'marketplace-asset-1' },
+                },
+              ])
+            : magmaOrderResponse()
+        )
+      );
+
+      await expect(
+        setupResolver.setupTradeCapacity(userId, purchaseInput)
+      ).rejects.toThrow('does not support asset channels');
+      expect(mockNodeService.pay).not.toHaveBeenCalled();
+    });
+
+    it('PURCHASE: rejects when the offer belongs to a different seller node', async () => {
+      mockFetchService.graphqlFetchWithProxy.mockImplementation((url: string) =>
+        Promise.resolve(
+          url === tradeUrl
+            ? offersResponse([
+                {
+                  id: 'offer-1',
+                  magma_offer_id: 'offer-1',
+                  node: { pubkey: 'ef'.repeat(33) },
+                  asset: {
+                    id: 'marketplace-asset-1',
+                    taproot_asset_details: { asset_id: 'deadbeef'.repeat(8) },
+                  },
+                },
+              ])
+            : magmaOrderResponse()
+        )
+      );
+
+      await expect(
+        setupResolver.setupTradeCapacity(userId, purchaseInput)
+      ).rejects.toThrow('does not support asset channels');
     });
 
     // ── Idempotency: skip steps when capacity already exists ──

--- a/src/server/modules/api/magma/magma.resolver.ts
+++ b/src/server/modules/api/magma/magma.resolver.ts
@@ -143,6 +143,24 @@ export class MagmaResolver {
             'Either tapdAssetId or tapdGroupKey must be provided'
           );
         }
+
+        // The buyer (this ThunderHub node) must run a reachable Taproot Assets
+        // daemon to open or receive asset channels. Enforce it here so an asset
+        // order can't be placed from a node that can't fulfil it — e.g. a plain
+        // LND node whose YAML was relabelled as `litd`. The client-side
+        // readiness UI (`has_tapd`) is advisory and can be bypassed.
+        const [, tapdErr] = await toWithError(
+          this.tapdNodeService.getInfo({ id: user.id })
+        );
+        if (tapdErr) {
+          this.logger.warn(
+            'Rejecting trade setup — node has no reachable Taproot Assets daemon',
+            { err: tapdErr }
+          );
+          throw new GraphQLError(
+            'This node does not support asset channels (no Taproot Assets daemon reachable)'
+          );
+        }
       },
 
       nodeInfo: async (): Promise<SetupTradeCapacityAuto['nodeInfo']> => {
@@ -304,10 +322,6 @@ export class MagmaResolver {
               );
               return undefined;
             }
-
-            // We're about to place a real asset-channel order — confirm the
-            // seller actually supports asset channels for this asset first.
-            await this.assertOfferSupportsAssetChannels(user, input);
           }
 
           const magmaUrl = await this.ambossService.resolveMagmaUrl(user);
@@ -591,71 +605,6 @@ export class MagmaResolver {
         (result.payMagma as { channelOpenPending?: boolean } | undefined)
           ?.channelOpenPending || undefined,
     };
-  }
-
-  /**
-   * Guards an asset-channel purchase: re-fetches the selected offer from the
-   * Amboss trade API and confirms the seller actually advertises asset-channel
-   * support for the requested Taproot asset. Without this, a manually crafted
-   * order (e.g. one that bypassed the client-side readiness UI) could be placed
-   * against a seller that cannot open asset channels — the order is paid but the
-   * channel never opens. Throws a GraphQLError when the offer is unsuitable.
-   */
-  private async assertOfferSupportsAssetChannels(
-    user: UserId,
-    input: SetupTradeCapacityInput
-  ): Promise<void> {
-    const tradeUrl = await this.ambossService.resolveTradeUrl(user);
-
-    const { data, error } = await this.fetchService.graphqlFetchWithProxy<{
-      public: { offers: { list: TradeApiOffer[] } };
-    }>(tradeUrl, getOffersQuery, {
-      input: {
-        asset_id: input.ambossAssetId,
-        transaction_type: input.transactionType,
-        page: { limit: 100, offset: 0 },
-      },
-    });
-
-    if (error || !data?.public?.offers) {
-      this.logger.error('Failed to verify seller asset-channel support', {
-        error,
-        magmaOfferId: input.magmaOfferId,
-      });
-      throw new GraphQLError(
-        'Could not verify that the seller supports asset channels — try again'
-      );
-    }
-
-    const offer = data.public.offers.list.find(
-      o => o.magma_offer_id === input.magmaOfferId
-    );
-
-    const details = offer?.asset?.taproot_asset_details;
-    const matchesAsset = input.tapdGroupKey
-      ? details?.group_key === input.tapdGroupKey
-      : details?.asset_id === input.tapdAssetId;
-
-    if (
-      !offer ||
-      offer.node?.pubkey !== input.swapNodePubkey ||
-      !matchesAsset
-    ) {
-      this.logger.warn(
-        'Rejecting Magma order — seller does not support asset channels for this asset',
-        {
-          magmaOfferId: input.magmaOfferId,
-          swapNodePubkey: input.swapNodePubkey,
-          ambossAssetId: input.ambossAssetId,
-          offerFound: !!offer,
-          offerPubkey: offer?.node?.pubkey,
-          hasAssetDetails: !!details,
-        }
-      );
-      throw new GraphQLError(
-        'The selected seller does not support asset channels for this asset'
-      );
-    }
   }
 }
 

--- a/src/server/modules/api/magma/magma.resolver.ts
+++ b/src/server/modules/api/magma/magma.resolver.ts
@@ -48,6 +48,7 @@ import {
   getOrdersQuery,
   getOrderPaymentQuery,
   cancelMagmaOrderMutation,
+  MAGMA_ORDER_REFERRER,
 } from './magma.gql';
 
 /**
@@ -303,6 +304,10 @@ export class MagmaResolver {
               );
               return undefined;
             }
+
+            // We're about to place a real asset-channel order — confirm the
+            // seller actually supports asset channels for this asset first.
+            await this.assertOfferSupportsAssetChannels(user, input);
           }
 
           const magmaUrl = await this.ambossService.resolveMagmaUrl(user);
@@ -346,6 +351,7 @@ export class MagmaResolver {
                   pubkey: nodeInfo.publicKey,
                   size: magmaSize,
                   payment_method: 'SATS',
+                  referrer: MAGMA_ORDER_REFERRER,
                   options: {
                     asset_id:
                       input.transactionType === TapTransactionType.PURCHASE
@@ -585,6 +591,71 @@ export class MagmaResolver {
         (result.payMagma as { channelOpenPending?: boolean } | undefined)
           ?.channelOpenPending || undefined,
     };
+  }
+
+  /**
+   * Guards an asset-channel purchase: re-fetches the selected offer from the
+   * Amboss trade API and confirms the seller actually advertises asset-channel
+   * support for the requested Taproot asset. Without this, a manually crafted
+   * order (e.g. one that bypassed the client-side readiness UI) could be placed
+   * against a seller that cannot open asset channels — the order is paid but the
+   * channel never opens. Throws a GraphQLError when the offer is unsuitable.
+   */
+  private async assertOfferSupportsAssetChannels(
+    user: UserId,
+    input: SetupTradeCapacityInput
+  ): Promise<void> {
+    const tradeUrl = await this.ambossService.resolveTradeUrl(user);
+
+    const { data, error } = await this.fetchService.graphqlFetchWithProxy<{
+      public: { offers: { list: TradeApiOffer[] } };
+    }>(tradeUrl, getOffersQuery, {
+      input: {
+        asset_id: input.ambossAssetId,
+        transaction_type: input.transactionType,
+        page: { limit: 100, offset: 0 },
+      },
+    });
+
+    if (error || !data?.public?.offers) {
+      this.logger.error('Failed to verify seller asset-channel support', {
+        error,
+        magmaOfferId: input.magmaOfferId,
+      });
+      throw new GraphQLError(
+        'Could not verify that the seller supports asset channels — try again'
+      );
+    }
+
+    const offer = data.public.offers.list.find(
+      o => o.magma_offer_id === input.magmaOfferId
+    );
+
+    const details = offer?.asset?.taproot_asset_details;
+    const matchesAsset = input.tapdGroupKey
+      ? details?.group_key === input.tapdGroupKey
+      : details?.asset_id === input.tapdAssetId;
+
+    if (
+      !offer ||
+      offer.node?.pubkey !== input.swapNodePubkey ||
+      !matchesAsset
+    ) {
+      this.logger.warn(
+        'Rejecting Magma order — seller does not support asset channels for this asset',
+        {
+          magmaOfferId: input.magmaOfferId,
+          swapNodePubkey: input.swapNodePubkey,
+          ambossAssetId: input.ambossAssetId,
+          offerFound: !!offer,
+          offerPubkey: offer?.node?.pubkey,
+          hasAssetDetails: !!details,
+        }
+      );
+      throw new GraphQLError(
+        'The selected seller does not support asset channels for this asset'
+      );
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

Closes two gaps behind the failed direct-Magma-asset-order incident (an LND node ordered an asset channel from a seller that doesn't support them; the order was paid but no channel opened).

**Root cause:** `setupTradeCapacity` only validated amounts/IDs before placing an order — it never confirmed the seller actually supports asset channels. The client-side readiness UI (`has_tapd`) was the only guard, so a request that bypassed the UI could place an order against an incompatible seller. (Note: flipping `lnd→litd` in the YAML does *not* fake `has_tapd` — `tapdNodeService.getInfo()` opens a real tapd gRPC connection and fails on a plain LND node — but nothing on the order path enforced it.)

## Changes

- **Server-side seller validation** (`magma.resolver.ts`): new `assertOfferSupportsAssetChannels()`, called for real PURCHASE orders (after the "capacity already sufficient" skip, so no wasted fetch). Re-fetches the offer from the Amboss trade API and rejects before payment unless the offer exists, the seller pubkey matches, and it carries `taproot_asset_details` matching the requested asset. Fails closed.
- **Referrer** (`magma.gql.ts`, `magma.resolver.ts`): every Magma order now sends `referrer: 'thunderhub'` (`MAGMA_ORDER_REFERRER`) so Amboss can attribute orders and avoid double-counting liquidity.
- **Tests**: added 4 cases (referrer tag, offer-not-found, no-taproot-details, wrong-seller-node) and reworked the fetch mock to route by URL.

## ⚠️ Deployment dependency

The `referrer` field is sent to Amboss's `CreateManualOrderInput`. **This deploy must land after the Rails/API change** that accepts `referrer`, or order creation will be rejected.

## Verification

`lint:check` clean · `build:nest` succeeds · 31/31 magma tests pass. No `schema.gql`/codegen change (only outbound Amboss variables + internal logic).
