### PR TITLE
Fix Sign Message copy button in non-secure contexts

### DIFF
--- a/src/client/src/views/tools/messages/SignMessage.tsx
+++ b/src/client/src/views/tools/messages/SignMessage.tsx
@@ -20,6 +20,26 @@ export const SignMessage = () => {
     }
   }, [loading, data]);
 
+  const copySignature = async () => {
+    try {
+      if (navigator.clipboard && window.isSecureContext) {
+        await navigator.clipboard.writeText(signed);
+      } else {
+        const textArea = document.createElement('textarea');
+        textArea.value = signed;
+        textArea.style.position = 'fixed';
+        textArea.style.opacity = '0';
+        document.body.appendChild(textArea);
+        textArea.select();
+        document.execCommand('copy');
+        document.body.removeChild(textArea);
+      }
+      toast.success('Signature Copied');
+    } catch {
+      toast.error('Failed to copy signature');
+    }
+  };
+
   return (
     <div className="space-y-2">
       <div className="flex gap-2">
@@ -41,15 +61,7 @@ export const SignMessage = () => {
         <div className="rounded border border-border bg-muted/50 p-3 text-center space-y-2">
           <p className="text-xs text-muted-foreground">Signature</p>
           <div className="text-sm font-mono break-all">{signed}</div>
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() =>
-              navigator.clipboard
-                .writeText(signed)
-                .then(() => toast.success('Signature Copied'))
-            }
-          >
+          <Button variant="outline" size="sm" onClick={copySignature}>
             <Copy size={14} />
             Copy
           </Button>


### PR DESCRIPTION
## Problem

On the Sign Message tool, the **Copy** button does nothing when ThunderHub is accessed over a non-secure context — plain HTTP, or a LAN / `.onion` / Tailscale address. In those contexts `navigator.clipboard` is `undefined`, so the existing handler:

```ts
navigator.clipboard.writeText(signed).then(() => toast.success('Signature Copied'))
```

throws immediately, and because there is no `.catch`, it fails silently with no feedback. Since most self-hosted ThunderHub instances are reached over exactly these non-HTTPS addresses, the button is effectively broken for a large share of users.

## Fix

Extract the copy handler and add a fallback: use the async Clipboard API when it is available in a secure context, otherwise fall back to a temporary `<textarea>` + `document.execCommand('copy')`. Both paths surface a success toast, and the handler is wrapped in try/catch so a failure shows an error toast instead of silently doing nothing.

## Testing

- Built and ran locally against a live LND node.
- Signed a message and clicked **Copy** over a non-HTTPS address (previously a no-op) — the success toast now appears and the clipboard is populated.
- Verified the copied signature is complete and valid via `lncli verifymessage` (`valid: true`).
